### PR TITLE
feat: Add usage instructions and configuration details for `phpstan.neon` in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,6 @@ parameters:
         config_path: %currentWorkingDirectory%/config/test.php
 ```
 
-to the require-dev section of your `composer.json` file.
-
 ## Quality code
 
 [![phpstan-level](https://img.shields.io/badge/PHPStan%20level-6-blue)](https://github.com/yii2-extensions/phpstan/actions/workflows/static.yml)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive "Usage" section to the README with step-by-step setup instructions for configuring the extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->