### PR TITLE
fix: Update the path to `Yii.php` in the `stubFiles` configuration for correct referencing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.2.2 June 04, 2025
 
 - Bug #22: Make `$configPath` optional in constructor `ServiceMap` class and update docs `README.md` (@terabytesoftw)
-- Bug #23: Update path to `Yii.php` in stubFiles for correct referencing (@terabytesoftw)
+- Bug #23: Update the path to `Yii.php` in the `stubFiles` configuration for correct referencing (@terabytesoftw)
 
 ## 0.2.1 June 03, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.2 June 04, 2025
 
 - Bug #22: Make `$configPath` optional in constructor `ServiceMap` class and update docs `README.md` (@terabytesoftw)
+- Bug #23: Update path to `Yii.php` in stubFiles for correct referencing (@terabytesoftw)
 
 ## 0.2.1 June 03, 2025
 

--- a/extension.neon
+++ b/extension.neon
@@ -11,7 +11,7 @@ parameters:
 
     stubFiles:
         - stubs/BaseYii.stub
-        - %rootDir%/../../../vendor/yiisoft/yii2/Yii.php
+        - %currentWorkingDirectory%/vendor/yiisoft/yii2/Yii.php
 
 parametersSchema:
 	yii2: structure(

--- a/extension.neon
+++ b/extension.neon
@@ -11,7 +11,7 @@ parameters:
 
     stubFiles:
         - stubs/BaseYii.stub
-        - vendor/yiisoft/yii2/Yii.php
+        - %rootDir%/../../../vendor/yiisoft/yii2/Yii.php
 
 parametersSchema:
 	yii2: structure(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the reference path for `Yii.php` to ensure correct file resolution in the configuration.

- **Documentation**
  - Added a changelog entry describing the fix for the `Yii.php` path issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->