### PR TITLE
feat(): Enable strict rules and bleeding edge analysis, and update `README.md` with strict configuration examples.

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -26,4 +26,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.4']

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -28,4 +28,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.4']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,4 +30,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.1']
+        ['8.4']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## 0.2.3 June 06, 2025
 
-- Enh #25: Add support for PHPStan Extension Installer (@samuelrajan747)
-- Enh #26: Add PHPStan extension installer instructions and improve `ServiceMap` configuration handling (@terabytesoftw)
+- Enh #25: Add support for `PHPStan` Extension Installer (@samuelrajan747)
+- Enh #26: Add `PHPStan` extension installer instructions and improve `ServiceMap` configuration handling (@terabytesoftw)
 - Bug #27: Enhance error handling in `ServiceMap` for invalid configuration structures and add corresponding test cases (@terabytesoftw)
 - Bug #28: Refactor component handling in `ServiceMap` to improve variable naming and streamline logic (@terabytesoftw)
+- Enh #29: Enable strict rules and bleeding edge analysis, and update `README.md` with strict configuration examples (@terabytesoftw)
 
 ## 0.2.2 June 04, 2025
 

--- a/README.md
+++ b/README.md
@@ -119,10 +119,12 @@ constants.
 To maintain the `Yii2` constants recognition, you must include them explicitly along with your custom constants, as
 shown above.
 
-### Advanced Configuration Example
+### Strict Configuration
 
 ```neon
 includes:
+    - phar://phpstan.phar/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
     - vendor/yii2-extensions/phpstan/extension.neon
 
 parameters:
@@ -154,6 +156,16 @@ parameters:
 
     yii2:
         config_path: %currentWorkingDirectory%/config/web.php
+
+    # Enable strict advanced checks
+    checkImplicitMixed: true
+    checkBenevolentUnionTypes: true
+    checkUninitializedProperties: true
+    checkMissingCallableSignature: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    reportAnyTypeWideningInVarTag: true
+    reportPossiblyNonexistentConstantArrayOffset: true
+    reportPossiblyNonexistentGeneralArrayOffset: true    
 ```
 
 ### PHPstan extension installer

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require-dev": {
         "maglnet/composer-require-checker": "^4.7",
         "phpstan/phpstan-phpunit": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0.3",
         "phpunit/phpunit": "^10.2",
         "symplify/easy-coding-standard": "^12.1"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,7 @@
 includes:
-	- extension.neon
-	- vendor/phpstan/phpstan-phpunit/extension.neon
-	- vendor/phpstan/phpstan-phpunit/rules.neon
-	- phar://phpstan.phar/conf/bleedingEdge.neon
+    - extension.neon
+    - phar://phpstan.phar/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
     bootstrapFiles:
@@ -16,3 +15,13 @@ parameters:
 
     paths:
         - src
+
+    # Enable strict advanced checks
+    checkImplicitMixed: true
+    checkBenevolentUnionTypes: true
+    checkUninitializedProperties: true
+    checkMissingCallableSignature: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    reportAnyTypeWideningInVarTag: true
+    reportPossiblyNonexistentConstantArrayOffset: true
+    reportPossiblyNonexistentGeneralArrayOffset: true

--- a/src/reflection/ApplicationPropertiesClassReflectionExtension.php
+++ b/src/reflection/ApplicationPropertiesClassReflectionExtension.php
@@ -142,6 +142,6 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
 
         return $classReflection->hasNativeProperty($propertyName)
             || $this->annotationsProperties->hasProperty($classReflection, $propertyName)
-            || $this->serviceMap->getComponentClassById($propertyName);
+            || $this->serviceMap->getComponentClassById($propertyName) !== null;
     }
 }

--- a/src/type/ActiveQueryDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveQueryDynamicMethodReturnTypeExtension.php
@@ -62,6 +62,8 @@ final class ActiveQueryDynamicMethodReturnTypeExtension implements DynamicMethod
      * Returns the class name for which this dynamic return type extension applies.
      *
      * @return string Fully qualified class name of the supported class.
+     *
+     * @phpstan-return class-string<\yii\db\ActiveQuery>
      */
     public function getClass(): string
     {

--- a/src/type/ActiveQueryDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveQueryDynamicMethodReturnTypeExtension.php
@@ -63,7 +63,7 @@ final class ActiveQueryDynamicMethodReturnTypeExtension implements DynamicMethod
      *
      * @return string Fully qualified class name of the supported class.
      *
-     * @phpstan-return class-string<\yii\db\ActiveQuery>
+     * @phpstan-return class-string
      */
     public function getClass(): string
     {

--- a/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
@@ -13,7 +13,6 @@ use PHPStan\Type\{DynamicMethodReturnTypeExtension, Type};
 use yii\db\ActiveRecord;
 
 use function count;
-use function get_class;
 use function in_array;
 use function sprintf;
 

--- a/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
@@ -91,7 +91,7 @@ final class ActiveRecordDynamicMethodReturnTypeExtension implements DynamicMetho
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
-        $arg = isset($methodCall->args[0]) ? $methodCall->args[0] : null;
+        $arg = $methodCall->args[0] ?? null;
 
         if ($arg instanceof Arg === false) {
             throw new ShouldNotHappenException(

--- a/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
@@ -60,6 +60,8 @@ final class ActiveRecordDynamicMethodReturnTypeExtension implements DynamicMetho
      * autocompletion for dynamic relation definitions.
      *
      * @return string Fully qualified class name of the supported {@see ActiveRecord} class.
+     *
+     * @phpstan-return class-string<\yii\db\ActiveRecord>
      */
     public function getClass(): string
     {
@@ -90,13 +92,12 @@ final class ActiveRecordDynamicMethodReturnTypeExtension implements DynamicMetho
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
-        $arg = $methodCall->args[0];
+        $arg = $methodCall->args[0] ?? null;
 
-        if ($arg instanceof Arg === false) {
+        if ($arg === null || $arg instanceof Arg === false) {
             throw new ShouldNotHappenException(
                 sprintf(
-                    'Unexpected arg %s during method call %s at line %d',
-                    get_class($arg),
+                    'Invalid or missing argument for method %s at line %d',
                     $methodReflection->getName(),
                     $methodCall->getLine(),
                 ),

--- a/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
@@ -91,9 +91,9 @@ final class ActiveRecordDynamicMethodReturnTypeExtension implements DynamicMetho
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
-        $arg = $methodCall->args[0] ?? null;
+        $arg = isset($methodCall->args[0]) ? $methodCall->args[0] : null;
 
-        if ($arg === null || $arg instanceof Arg === false) {
+        if ($arg instanceof Arg === false) {
             throw new ShouldNotHappenException(
                 sprintf(
                     'Invalid or missing argument for method %s at line %d',

--- a/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicMethodReturnTypeExtension.php
@@ -60,7 +60,7 @@ final class ActiveRecordDynamicMethodReturnTypeExtension implements DynamicMetho
      *
      * @return string Fully qualified class name of the supported {@see ActiveRecord} class.
      *
-     * @phpstan-return class-string<\yii\db\ActiveRecord>
+     * @phpstan-return class-string
      */
     public function getClass(): string
     {
@@ -91,7 +91,7 @@ final class ActiveRecordDynamicMethodReturnTypeExtension implements DynamicMetho
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
-        $arg = $methodCall->args[0] ?? null;
+        $arg = $methodCall->getRawArgs()[0] ?? null;
 
         if ($arg instanceof Arg === false) {
             throw new ShouldNotHappenException(

--- a/src/type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
@@ -68,6 +68,8 @@ final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements Dynami
      * return type inference is applied to the correct class hierarchy during static analysis and IDE autocompletion.
      *
      * @return string Fully qualified class name of the supported {@see ActiveRecord} class.
+     *
+     * @phpstan-return class-string<\yii\db\ActiveRecord>
      */
     public function getClass(): string
     {

--- a/src/type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
@@ -69,7 +69,7 @@ final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements Dynami
      *
      * @return string Fully qualified class name of the supported {@see ActiveRecord} class.
      *
-     * @phpstan-return class-string<\yii\db\ActiveRecord>
+     * @phpstan-return class-string
      */
     public function getClass(): string
     {

--- a/src/type/ContainerDynamicMethodReturnTypeExtension.php
+++ b/src/type/ContainerDynamicMethodReturnTypeExtension.php
@@ -56,6 +56,8 @@ final class ContainerDynamicMethodReturnTypeExtension implements DynamicMethodRe
      * return type logic is applied to service resolution calls.
      *
      * @return string Fully qualified class name of the supported container class.
+     *
+     * @phpstan-return class-string<\yii\di\Container>
      */
     public function getClass(): string
     {

--- a/src/type/ContainerDynamicMethodReturnTypeExtension.php
+++ b/src/type/ContainerDynamicMethodReturnTypeExtension.php
@@ -57,7 +57,7 @@ final class ContainerDynamicMethodReturnTypeExtension implements DynamicMethodRe
      *
      * @return string Fully qualified class name of the supported container class.
      *
-     * @phpstan-return class-string<\yii\di\Container>
+     * @phpstan-return class-string
      */
     public function getClass(): string
     {

--- a/src/type/HeaderCollectionDynamicMethodReturnTypeExtension.php
+++ b/src/type/HeaderCollectionDynamicMethodReturnTypeExtension.php
@@ -59,7 +59,7 @@ final class HeaderCollectionDynamicMethodReturnTypeExtension implements DynamicM
      *
      * @return string Fully qualified class name of the supported header collection class.
      *
-     * @phpstan-return class-string<\yii\web\HeaderCollection>
+     * @phpstan-return class-string
      */
     public function getClass(): string
     {
@@ -74,7 +74,7 @@ final class HeaderCollectionDynamicMethodReturnTypeExtension implements DynamicM
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
-        $args = $methodCall->args ?? [];
+        $args = $methodCall->getArgs();
 
         if (count($args) < 3) {
             return new StringType();

--- a/src/type/HeaderCollectionDynamicMethodReturnTypeExtension.php
+++ b/src/type/HeaderCollectionDynamicMethodReturnTypeExtension.php
@@ -48,6 +48,19 @@ use function count;
  */
 final class HeaderCollectionDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+    /**
+     * Returns the class name for which this dynamic return type extension applies.
+     *
+     * Specifies the fully qualified class name of the Yii {@see HeaderCollection} class that this extension targets
+     * for dynamic return type inference in PHPStan analysis.
+     *
+     * This enables PHPStan to apply custom return type logic for the {@see HeaderCollection::get()} method, supporting
+     * accurate type inference and IDE autocompletion for header value retrieval in Yii HTTP handling.
+     *
+     * @return string Fully qualified class name of the supported header collection class.
+     *
+     * @phpstan-return class-string<\yii\web\HeaderCollection>
+     */
     public function getClass(): string
     {
         return HeaderCollection::class;
@@ -61,12 +74,14 @@ final class HeaderCollectionDynamicMethodReturnTypeExtension implements DynamicM
         MethodCall $methodCall,
         Scope $scope,
     ): Type {
-        if (count($methodCall->args) < 3) {
+        $args = $methodCall->args ?? [];
+
+        if (count($args) < 3) {
             return new StringType();
         }
 
         /** @var Arg $arg */
-        $arg = $methodCall->args[2];
+        $arg = $args[2] ?? null;
 
         if ($arg->value instanceof ConstFetch) {
             $value = $arg->value->name->getParts()[0];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated README with stricter PHPStan configuration examples and renamed the advanced configuration section.
  - Improved changelog formatting and added details about new enhancements.
- **Chores**
  - Added phpstan-strict-rules as a development dependency.
  - Enhanced PHPStan configuration for stricter static analysis.
  - Updated GitHub Actions workflows to use PHP 8.4.
- **Style**
  - Added detailed PHPDoc and PHPStan-specific annotations to improve static analysis and type inference.
- **Refactor**
  - Improved code clarity and safety in several methods by refining condition checks and argument handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->