### PR TITLE
Add support for IdentityClass Components

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -5,6 +5,11 @@ parameters:
         - YII_ENV_DEV
         - YII_ENV_PROD
         - YII_ENV_TEST
+    stubFiles:
+        - stubs/Configurable.stub
+        - stubs/BaseObject.stub
+        - stubs/Component.stub
+        - stubs/User.stub
 
     yii2:
         config_path: ''

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -77,6 +77,11 @@ final class ServiceMap
     private array $components = [];
 
     /**
+     * @phpstan-var array<string, string>
+     */
+    private array $userComponents = [];
+
+    /**
      * Creates a new instance of the {@see ServiceMap} class.
      *
      * @param string $configPath Path to the Yii application configuration file (default: `''`). If provided, the
@@ -121,6 +126,16 @@ final class ServiceMap
     public function getComponentClassById(string $id): string|null
     {
         return $this->components[$id] ?? null;
+    }
+
+    public function isUserComponentClass(string $id): bool
+    {
+        return key_exists($id, $this->userComponents);
+    }
+
+    public function getUserComponentClassById(string $id): string|null
+    {
+        return $this->userComponents[$id] ?? null;
     }
 
     /**
@@ -282,7 +297,12 @@ final class ServiceMap
                 }
 
                 if (isset($definition['class']) && is_string($definition['class']) && $definition['class'] !== '') {
-                    $this->components[$id] = $definition['class'];
+                    if ($definition['class'] === 'yii\web\User' && isset($definition['identityClass']) && is_string($definition['identityClass']) && $definition['identityClass'] !== '') {
+                        $this->processUserComponent($id, $definition['identityClass']);
+                    }
+                    else {
+                        $this->components[$id] = $definition['class'];
+                    }
                 }
             }
         }
@@ -350,6 +370,10 @@ final class ServiceMap
                 $this->services[$id] = $this->normalizeDefinition($id, $service);
             }
         }
+    }
+
+    private function processUserComponent(string $id, string $identityClass) {
+        $this->userComponents[$id] = $identityClass;
     }
 
     /**

--- a/src/reflection/ApplicationPropertiesClassReflectionExtension.php
+++ b/src/reflection/ApplicationPropertiesClassReflectionExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\{
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Generic\GenericObjectType;
 use yii2\extensions\phpstan\ServiceMap;
 
 /**
@@ -94,6 +95,14 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
             return new ComponentPropertyReflection(
                 new DummyPropertyReflection($propertyName),
                 new ObjectType($componentClass),
+                $classReflection,
+            );
+        }
+
+        if ($this->serviceMap->isUserComponentClass($propertyName)) {
+            return new ComponentPropertyReflection(
+                new DummyPropertyReflection($propertyName),
+                new GenericObjectType('yii\web\User', [new ObjectType($this->serviceMap->getUserComponentClassById($propertyName))]),
                 $classReflection,
             );
         }

--- a/src/reflection/UserPropertiesClassReflectionExtension.php
+++ b/src/reflection/UserPropertiesClassReflectionExtension.php
@@ -74,21 +74,15 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {
         if (
-            $propertyName === 'identity' &&
-            ($componentClass = $this->serviceMap->getComponentClassById($propertyName)) !== null
+            $propertyName === 'identity'
         ) {
-            return new ComponentPropertyReflection(
-                new DummyPropertyReflection($propertyName),
-                new ObjectType($componentClass),
-                $classReflection,
-            );
+            return $this->annotationsProperties->getProperty($classReflection, $propertyName);
         }
 
         if ($classReflection->hasNativeProperty($propertyName)) {
             return $classReflection->getNativeProperty($propertyName);
         }
 
-        return $this->annotationsProperties->getProperty($classReflection, $propertyName);
     }
 
     /**

--- a/stubs/BaseObject.stub
+++ b/stubs/BaseObject.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\base;
+
+class BaseObject implements Configurable {}

--- a/stubs/Component.stub
+++ b/stubs/Component.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\base;
+
+class Component extends BaseObject {}

--- a/stubs/Configurable.stub
+++ b/stubs/Configurable.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\base;
+
+interface Configurable {}

--- a/stubs/User.stub
+++ b/stubs/User.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace yii\web;
+
+/**
+ * @template T of IdentityInterface
+ * @property ?T $identity
+ */
+class User extends Component {}


### PR DESCRIPTION
Added support for IdentityClass Components implemented by yii\web\User.
This is acheived by using genric types in yii\web\User (stubs for now).
Need to update inline comments (PHPDocs).
Need to write tests.
Need to upstream the addition of generic type in yii\web\User to Yii.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |