### PR TITLE
Add support for `yii\web\User` Components (Identity Property)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bug #27: Enhance error handling in `ServiceMap` for invalid configuration structures and add corresponding test cases (@terabytesoftw)
 - Bug #28: Refactor component handling in `ServiceMap` to improve variable naming and streamline logic (@terabytesoftw)
 - Enh #29: Enable strict rules and bleeding edge analysis, and update `README.md` with strict configuration examples (@terabytesoftw)
+- Enh #31: Add support for IdentityClass Components (@samuelrajan747)
 
 ## 0.2.2 June 04, 2025
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@
     </a>
     <a href="https://github.com/yiisoft/yii2/tree/22.0" target="_blank">
         <img src="https://img.shields.io/badge/Yii2%20-22-blue" alt="Yii2-22">
-    </a>    
+    </a>
     <a href="https://github.com/yii2-extensions/phpstan/actions/workflows/build.yml" target="_blank">
         <img src="https://github.com/yii2-extensions/phpstan/actions/workflows/build.yml/badge.svg" alt="PHPUnit">
     </a>
-    <a href="https://github.com/yii2-extensions/phpstan/actions/workflows/static.yml" target="_blank">        
+    <a href="https://github.com/yii2-extensions/phpstan/actions/workflows/static.yml" target="_blank">
         <img src="https://github.com/yii2-extensions/phpstan/actions/workflows/static.yml/badge.svg" alt="Static-Analysis">
-    </a>          
+    </a>
     <a href="https://codecov.io/gh/yii2-extensions/phpstan" target="_blank">
         <img src="https://codecov.io/gh/yii2-extensions/phpstan/branch/main/graph/badge.svg?token=MF0XUGVLYC" alt="Codecov">
-    </a>  
+    </a>
 </p>
 
 ## Installation
@@ -139,10 +139,10 @@ parameters:
         - YII_ENV_PROD
         - YII_ENV_TEST
         - APP_VERSION
-        - MAINTENANCE_MODE        
+        - MAINTENANCE_MODE
 
-    level: 8    
-    
+    level: 8
+
     paths:
         - src
         - controllers
@@ -165,7 +165,7 @@ parameters:
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
     reportAnyTypeWideningInVarTag: true
     reportPossiblyNonexistentConstantArrayOffset: true
-    reportPossiblyNonexistentGeneralArrayOffset: true    
+    reportPossiblyNonexistentGeneralArrayOffset: true
 ```
 
 ### PHPstan extension installer

--- a/extension.neon
+++ b/extension.neon
@@ -5,6 +5,11 @@ parameters:
         - YII_ENV_DEV
         - YII_ENV_PROD
         - YII_ENV_TEST
+    stubFiles:
+        - stubs/Configurable.stub
+        - stubs/BaseObject.stub
+        - stubs/Component.stub
+        - stubs/User.stub
 
     yii2:
         config_path: ''

--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,7 @@ parameters:
         - stubs/Configurable.stub
         - stubs/BaseObject.stub
         - stubs/Component.stub
+        - stubs/IdentityInterface.stub
         - stubs/User.stub
 
     yii2:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,7 +21,7 @@
         </include>
         <exclude>
             <directory suffix=".php">./src/reflection</directory>
-        <directory suffix=".php">./src/type</directory>
+            <directory suffix=".php">./src/type</directory>
         </exclude>
     </source>
 </phpunit>

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -77,6 +77,11 @@ final class ServiceMap
     private array $components = [];
 
     /**
+     * @phpstan-var array<string, string>
+     */
+    private array $userComponents = [];
+
+    /**
      * Creates a new instance of the {@see ServiceMap} class.
      *
      * @param string $configPath Path to the Yii application configuration file (default: `''`). If provided, the
@@ -121,6 +126,16 @@ final class ServiceMap
     public function getComponentClassById(string $id): string|null
     {
         return $this->components[$id] ?? null;
+    }
+
+    public function isUserComponentClass(string $id): bool
+    {
+        return key_exists($id, $this->userComponents);
+    }
+
+    public function getUserComponentClassById(string $id): string|null
+    {
+        return $this->userComponents[$id] ?? null;
     }
 
     /**
@@ -282,7 +297,12 @@ final class ServiceMap
                 }
 
                 if (isset($definition['class']) && is_string($definition['class']) && $definition['class'] !== '') {
-                    $this->components[$id] = $definition['class'];
+                    if ($definition['class'] === 'yii\web\User' && isset($definition['identityClass']) && is_string($definition['identityClass']) && $definition['identityClass'] !== '') {
+                        $this->processUserComponent($id, $definition['identityClass']);
+                    }
+                    else {
+                        $this->components[$id] = $definition['class'];
+                    }
                 }
             }
         }
@@ -350,6 +370,10 @@ final class ServiceMap
                 $this->services[$id] = $this->normalizeDefinition($id, $service);
             }
         }
+    }
+
+    private function processUserComponent(string $id, string $identityClass) {
+        $this->userComponents[$id] = $identityClass;
     }
 
     /**

--- a/src/reflection/ApplicationPropertiesClassReflectionExtension.php
+++ b/src/reflection/ApplicationPropertiesClassReflectionExtension.php
@@ -13,8 +13,8 @@ use PHPStan\Reflection\{
 };
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\Dummy\DummyPropertyReflection;
-use PHPStan\Type\ObjectType;
 use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
 use yii2\extensions\phpstan\ServiceMap;
 
 /**
@@ -99,10 +99,11 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
             );
         }
 
-        if ($this->serviceMap->isUserComponentClass($propertyName)) {
+        $identityClass = $this->serviceMap->getUserComponentClassById($propertyName);
+        if (!is_null($identityClass)) {
             return new ComponentPropertyReflection(
                 new DummyPropertyReflection($propertyName),
-                new GenericObjectType('yii\web\User', [new ObjectType($this->serviceMap->getUserComponentClassById($propertyName))]),
+                new GenericObjectType('yii\web\User', [new ObjectType($identityClass)]),
                 $classReflection,
             );
         }

--- a/src/reflection/ApplicationPropertiesClassReflectionExtension.php
+++ b/src/reflection/ApplicationPropertiesClassReflectionExtension.php
@@ -16,6 +16,9 @@ use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
 use yii2\extensions\phpstan\ServiceMap;
+use yii\base\Application as BaseApplication;
+use yii\web\Application as WebApplication;
+use yii\web\User;
 
 /**
  * Provides property reflection for Yii application components in PHPStan analysis.
@@ -87,8 +90,8 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
      */
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {
-        if ($classReflection->getName() !== \yii\web\Application::class) {
-            $classReflection = $this->reflectionProvider->getClass(\yii\web\Application::class);
+        if ($classReflection->getName() !== WebApplication::class) {
+            $classReflection = $this->reflectionProvider->getClass(WebApplication::class);
         }
 
         if (null !== $componentClass = $this->serviceMap->getComponentClassById($propertyName)) {
@@ -99,11 +102,10 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
             );
         }
 
-        $identityClass = $this->serviceMap->getUserComponentClassById($propertyName);
-        if (!is_null($identityClass)) {
+        if (null !== $userComponentClass = $this->serviceMap->getUserComponentClassById($propertyName)) {
             return new ComponentPropertyReflection(
                 new DummyPropertyReflection($propertyName),
-                new GenericObjectType('yii\web\User', [new ObjectType($identityClass)]),
+                new GenericObjectType(User::class, [new ObjectType($userComponentClass)]),
                 $classReflection,
             );
         }
@@ -137,17 +139,17 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
      */
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
-        $reflectionProviderBaseApplication = $this->reflectionProvider->getClass(\yii\base\Application::class);
+        $reflectionProviderBaseApplication = $this->reflectionProvider->getClass(BaseApplication::class);
 
         if (
-            $classReflection->getName() !== \yii\base\Application::class &&
+            $classReflection->getName() !== BaseApplication::class &&
             $classReflection->isSubclassOfClass($reflectionProviderBaseApplication) === false
         ) {
             return false;
         }
 
-        if ($classReflection->getName() !== \yii\web\Application::class) {
-            $classReflection = $this->reflectionProvider->getClass(\yii\web\Application::class);
+        if ($classReflection->getName() !== WebApplication::class) {
+            $classReflection = $this->reflectionProvider->getClass(WebApplication::class);
         }
 
         return $classReflection->hasNativeProperty($propertyName)

--- a/src/reflection/ApplicationPropertiesClassReflectionExtension.php
+++ b/src/reflection/ApplicationPropertiesClassReflectionExtension.php
@@ -15,10 +15,10 @@ use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension
 use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Type\Generic\GenericObjectType;
 use PHPStan\Type\ObjectType;
-use yii2\extensions\phpstan\ServiceMap;
 use yii\base\Application as BaseApplication;
 use yii\web\Application as WebApplication;
 use yii\web\User;
+use yii2\extensions\phpstan\ServiceMap;
 
 /**
  * Provides property reflection for Yii application components in PHPStan analysis.
@@ -154,6 +154,7 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
 
         return $classReflection->hasNativeProperty($propertyName)
             || $this->annotationsProperties->hasProperty($classReflection, $propertyName)
-            || $this->serviceMap->getComponentClassById($propertyName) !== null;
+            || $this->serviceMap->getComponentClassById($propertyName) !== null
+            || $this->serviceMap->getUserComponentClassById($propertyName) !== null;
     }
 }

--- a/src/reflection/ApplicationPropertiesClassReflectionExtension.php
+++ b/src/reflection/ApplicationPropertiesClassReflectionExtension.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\{
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\Generic\GenericObjectType;
 use yii2\extensions\phpstan\ServiceMap;
 
 /**
@@ -94,6 +95,14 @@ final class ApplicationPropertiesClassReflectionExtension implements PropertiesC
             return new ComponentPropertyReflection(
                 new DummyPropertyReflection($propertyName),
                 new ObjectType($componentClass),
+                $classReflection,
+            );
+        }
+
+        if ($this->serviceMap->isUserComponentClass($propertyName)) {
+            return new ComponentPropertyReflection(
+                new DummyPropertyReflection($propertyName),
+                new GenericObjectType('yii\web\User', [new ObjectType($this->serviceMap->getUserComponentClassById($propertyName))]),
                 $classReflection,
             );
         }

--- a/src/reflection/UserPropertiesClassReflectionExtension.php
+++ b/src/reflection/UserPropertiesClassReflectionExtension.php
@@ -74,21 +74,15 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {
         if (
-            $propertyName === 'identity' &&
-            ($componentClass = $this->serviceMap->getComponentClassById($propertyName)) !== null
+            $propertyName === 'identity'
         ) {
-            return new ComponentPropertyReflection(
-                new DummyPropertyReflection($propertyName),
-                new ObjectType($componentClass),
-                $classReflection,
-            );
+            return $this->annotationsProperties->getProperty($classReflection, $propertyName);
         }
 
         if ($classReflection->hasNativeProperty($propertyName)) {
             return $classReflection->getNativeProperty($propertyName);
         }
 
-        return $this->annotationsProperties->getProperty($classReflection, $propertyName);
     }
 
     /**

--- a/src/reflection/UserPropertiesClassReflectionExtension.php
+++ b/src/reflection/UserPropertiesClassReflectionExtension.php
@@ -71,9 +71,7 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
      */
     public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
     {
-        if (
-            $propertyName === 'identity'
-        ) {
+        if ($propertyName === 'identity') {
             return $this->annotationsProperties->getProperty($classReflection, $propertyName);
         }
 
@@ -106,7 +104,7 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
             return false;
         }
 
-        if ($propertyName === 'identity' && $this->serviceMap->getComponentClassById($propertyName) !== null) {
+        if ($propertyName === 'identity' && $this->serviceMap->getUserComponentClassById($propertyName) !== null) {
             return true;
         }
 

--- a/src/reflection/UserPropertiesClassReflectionExtension.php
+++ b/src/reflection/UserPropertiesClassReflectionExtension.php
@@ -11,8 +11,6 @@ use PHPStan\Reflection\{
     PropertyReflection,
 };
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
-use PHPStan\Reflection\Dummy\DummyPropertyReflection;
-use PHPStan\Type\ObjectType;
 use yii\web\User;
 use yii2\extensions\phpstan\ServiceMap;
 
@@ -83,6 +81,7 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
             return $classReflection->getNativeProperty($propertyName);
         }
 
+        return $this->annotationsProperties->getProperty($classReflection, $propertyName);
     }
 
     /**

--- a/stubs/BaseObject.stub
+++ b/stubs/BaseObject.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\base;
+
+class BaseObject implements Configurable {}

--- a/stubs/Component.stub
+++ b/stubs/Component.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\base;
+
+class Component extends BaseObject {}

--- a/stubs/Configurable.stub
+++ b/stubs/Configurable.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\base;
+
+interface Configurable {}

--- a/stubs/IdentityInterface.stub
+++ b/stubs/IdentityInterface.stub
@@ -1,0 +1,5 @@
+<?php
+
+namespace yii\web;
+
+interface IdentityInterface {}

--- a/stubs/User.stub
+++ b/stubs/User.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace yii\web;
+
+/**
+ * @template T of IdentityInterface
+ * @property ?T $identity
+ */
+class User extends Component {}

--- a/stubs/User.stub
+++ b/stubs/User.stub
@@ -2,6 +2,8 @@
 
 namespace yii\web;
 
+use yii\base\Component;
+
 /**
  * @template T of IdentityInterface
  * @property ?T $identity

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -14,6 +14,7 @@ use SplStack;
 use yii\base\InvalidArgumentException;
 use yii2\extensions\phpstan\ServiceMap;
 use yii2\extensions\phpstan\tests\stub\MyActiveRecord;
+use yii2\extensions\phpstan\tests\stub\MyUser;
 
 /**
  * Test suite for {@see ServiceMap} class functionality and behavior.
@@ -110,6 +111,24 @@ final class ServiceMapTest extends TestCase
             MyActiveRecord::class,
             $serviceMap->getComponentClassById('customComponent'),
             'ServiceMap should resolve component id \'customComponent\' to \'MyActiveRecord::class\'.',
+        );
+        $this->assertNull(
+            $serviceMap->getComponentClassById('customUser'),
+            'ServiceMap should not resolve component id \'customUser\' to \'User::class\'.',
+        );
+        $this->assertSame(
+            MyUser::class,
+            $serviceMap->getUserComponentClassById('customUser'),
+            'ServiceMap should resolve user component id \'customUser\' to \'MyUser::class\'.',
+        );
+        $this->assertNull(
+            $serviceMap->getComponentClassById('customInitializedUser'),
+            'ServiceMap should not resolve component id \'customInitializedUser\' to \'User::class\'.',
+        );
+        $this->assertSame(
+            MyUser::class,
+            $serviceMap->getUserComponentClassById('customInitializedUser'),
+            'ServiceMap should resolve user component id \'customInitializedUser\' to \'MyUser::class\'.',
         );
         $this->assertNull(
             $serviceMap->getComponentClassById('nonExistentComponent'),

--- a/tests/fixture/config.php
+++ b/tests/fixture/config.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use yii\web\User;
 use yii2\extensions\phpstan\tests\stub\MyActiveRecord;
+use yii2\extensions\phpstan\tests\stub\MyUser;
 
 return [
     'components' => [
@@ -13,6 +15,11 @@ return [
             'class' => MyActiveRecord::class,
         ],
         'customInitializedComponent' => new MyActiveRecord(),
+        'customUser' => [
+            'class' => User::class,
+            'identityClass' => MyUser::class,
+        ],
+        'customInitializedUser' => new User(['identityClass' => MyUser::class]),
     ],
     'container' => [
         'singletons' => [

--- a/tests/stub/MyUser.php
+++ b/tests/stub/MyUser.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\db\ActiveRecord;
+use yii\web\IdentityInterface;
+
+class MyUser extends ActiveRecord implements IdentityInterface
+{
+    public static function findIdentity($id)
+    {
+        return new static();
+    }
+
+    public static function findIdentityByAccessToken($token, $type = null)
+    {
+        return new static();
+    }
+
+    public function getId()
+    {
+        return 1;
+    }
+
+    public function getAuthKey()
+    {
+        return '';
+    }
+
+    public function validateAuthKey($authKey)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Added support for **`yii\web\User`** Components.
This is achieved by using generic types in **`yii\web\User`** (stubs for now).
Need to update inline comments (PHPDocs).
Need to write tests.
Need to upstream the addition of generic type in `yii\web\User` to Yii.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  |

## **Before:**
### The Problem
As per the yii2 docs.
As of now, `Yii::$app->__user_component_name__->identity` after successful login will return `\yii\web\IdentityInterface`, irrespective of what is defined in `$config['components']['__user_component_name__']['identityClass']`.
### Expected Outcome
`Yii::$app->__user_component_name__->identity` after successful login should return instance of class mentioned in `$config['components']['__user_component_name__']['identityClass']`.

## After:
`Yii::$app->__user_component_name__->identity` after successful login will return whatever class mentioned in `$config['components']['__user_component_name__']['identityClass']` which should be implementing `yii\web\IdentityInterface`

## How it works:
- A generic type `T of yii\web\IdentityInterface` is added to the `yii\web\User` class in the class level. 
- All references to `yii\web\IdentityInterface` in `yii\web\User` is replaced with generic type `T`.
- An array of mapping between component names and identity class names is obtained by the service map when the extension initializes.
- Whenever a component of type `yii\web\User` is accessed in `yii\web\Application`, a class property of generic object type with class `yii\web\User` and generic type `T` is set to `identityClass` defined in `$config['components']['__user_component_name__']['identityClass']` is returned.
- Whenever `identity` property of `yii\web\User` is accessed, the property reflection is derived from the PHPDoc annotation in `yii\web\User` is returned.
- This works because the generic type `T of yii\web\IdentityInterface` of `yii\web\User` is set to the `$config['components']['__user_component_name__']['identityClass']` earlier. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for IdentityClass components, enabling enhanced handling of user components and identity classes.
  - Introduced new stub files for Yii base and web classes, including `BaseObject`, `Component`, `Configurable`, `IdentityInterface`, and `User`.
- **Bug Fixes**
  - Improved type specificity for user-related properties in application property reflection.
- **Documentation**
  - Updated changelog and improved README formatting and configuration examples.
- **Tests**
  - Added tests and stubs to verify correct handling of user components and identity classes.
- **Chores**
  - Updated configuration files to include new stub files and user component definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->