### PR TITLE
fix: Enhance `ActiveRecordDynamicStaticMethodReturnTypeExtension` type inference for `ActiveQuery` support, and fix phpstan errors max lvl in tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bug #27: Enhance error handling in `ServiceMap` for invalid configuration structures and add corresponding test cases (@terabytesoftw)
 - Bug #28: Refactor component handling in `ServiceMap` to improve variable naming and streamline logic (@terabytesoftw)
 - Enh #29: Enable strict rules and bleeding edge analysis, and update `README.md` with strict configuration examples (@terabytesoftw)
+- Bug #33: Enhance `ActiveRecordDynamicStaticMethodReturnTypeExtension` type inference for `ActiveQuery` support, and fix phpstan errors max lvl in tests (@terabytesoftw)
 
 ## 0.2.2 June 04, 2025
 

--- a/src/type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordDynamicStaticMethodReturnTypeExtension.php
@@ -130,6 +130,10 @@ final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements Dynami
         if (count($classNames) > 0) {
             $className = $classNames[0];
 
+            if ($className === ActiveQuery::class) {
+                return true;
+            }
+
             if ($this->reflectionProvider->hasClass($className)) {
                 $classReflection = $this->reflectionProvider->getClass($className);
 
@@ -165,6 +169,7 @@ final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements Dynami
         Scope $scope,
     ): Type {
         $className = $methodCall->class;
+
         $returnType = ParametersAcceptorSelector::selectFromArgs(
             $scope,
             $methodCall->getArgs(),
@@ -185,6 +190,12 @@ final class ActiveRecordDynamicStaticMethodReturnTypeExtension implements Dynami
             return TypeCombinator::union(new NullType(), new ActiveRecordObjectType($name));
         }
 
-        return new ActiveQueryObjectType($name, false);
+        $classNames = $returnType->getObjectClassNames();
+
+        if (count($classNames) > 0 && $classNames[0] === ActiveQuery::class) {
+            return new ActiveQueryObjectType($name, false);
+        }
+
+        return $returnType;
     }
 }

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -62,65 +62,65 @@ final class ServiceMapTest extends TestCase
 
         $serviceMap = new ServiceMap($fixturePath);
 
-        $this->assertNull(
+        self::assertNull(
             $serviceMap->getServiceClassFromNode(new String_('non-existent-service')),
             'ServiceMap should return \'null\' for a \'non-existent service\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             MyActiveRecord::class,
             $serviceMap->getServiceClassFromNode(new String_('singleton-string')),
             'ServiceMap should resolve \'singleton-string\' to \'MyActiveRecord::class\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             MyActiveRecord::class,
             $serviceMap->getServiceClassFromNode(new String_(MyActiveRecord::class)),
             'ServiceMap should resolve \'MyActiveRecord::class\' as a singleton string service.',
         );
-        $this->assertSame(
+        self::assertSame(
             SplStack::class,
             $serviceMap->getServiceClassFromNode(new String_('singleton-closure')),
             'ServiceMap should resolve \'singleton-closure\' to \'SplStack::class\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             SplObjectStorage::class,
             $serviceMap->getServiceClassFromNode(new String_('singleton-service')),
             'ServiceMap should resolve \'singleton-service\' to \'SplObjectStorage::class\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             SplFileInfo::class,
             $serviceMap->getServiceClassFromNode(new String_('singleton-nested-service-class')),
             'ServiceMap should resolve \'singleton-nested-service-class\' to \'SplFileInfo::class\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             SplStack::class,
             $serviceMap->getServiceClassFromNode(new String_('closure')),
             'ServiceMap should resolve \'closure\' to \'SplStack::class\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             SplObjectStorage::class,
             $serviceMap->getServiceClassFromNode(new String_('service')),
             'ServiceMap should resolve \'service\' to \'SplObjectStorage::class\'.',
         );
-        $this->assertSame(
+        self::assertSame(
             SplFileInfo::class,
             $serviceMap->getServiceClassFromNode(new String_('nested-service-class')),
             'ServiceMap should resolve \'nested-service-class\' to \'SplFileInfo::class\'.',
         );
-        $this->assertSame(
+       self::assertSame(
             MyActiveRecord::class,
             $serviceMap->getComponentClassById('customComponent'),
             'ServiceMap should resolve component id \'customComponent\' to \'MyActiveRecord::class\'.',
         );
-        $this->assertNull(
+        self::assertNull(
             $serviceMap->getComponentClassById('nonExistentComponent'),
             'ServiceMap should return \'null\' for a \'non-existent\' component id.',
         );
-        $this->assertSame(
+        self::assertSame(
             MyActiveRecord::class,
             $serviceMap->getComponentClassById('customInitializedComponent'),
             'ServiceMap should resolve component id \'customInitializedComponent\' to \'MyActiveRecord::class\'.',
         );
-        $this->assertNull(
+        self::assertNull(
             $serviceMap->getComponentClassById('assetManager'),
             'ServiceMap should return \'null\' for \'assetManager\' component id as it is not a class but an array.',
         );

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -106,11 +106,11 @@ final class ServiceMapTest extends TestCase
             $serviceMap->getServiceClassFromNode(new String_('nested-service-class')),
             'ServiceMap should resolve \'nested-service-class\' to \'SplFileInfo::class\'.',
         );
-       self::assertSame(
-           MyActiveRecord::class,
-           $serviceMap->getComponentClassById('customComponent'),
-           'ServiceMap should resolve component id \'customComponent\' to \'MyActiveRecord::class\'.',
-       );
+        self::assertSame(
+            MyActiveRecord::class,
+            $serviceMap->getComponentClassById('customComponent'),
+            'ServiceMap should resolve component id \'customComponent\' to \'MyActiveRecord::class\'.',
+        );
         self::assertNull(
             $serviceMap->getComponentClassById('nonExistentComponent'),
             'ServiceMap should return \'null\' for a \'non-existent\' component id.',

--- a/tests/stub/MyController.php
+++ b/tests/stub/MyController.php
@@ -47,7 +47,7 @@ final class MyController extends Controller
 
         $record = MyActiveRecord::find()->where(['flag' => Yii::$app->request->post('flag', true)])->one();
 
-        if ($record) {
+        if ($record !== null) {
             $record->flag = false;
             $flag = $record[$offsetProp];
             $record[$offsetProp] = true;
@@ -56,14 +56,14 @@ final class MyController extends Controller
 
         $record = MyActiveRecord::findOne(['condition']);
 
-        if ($record) {
+        if ($record !== null) {
             $flag = $record->flag;
             $flag = $record['flag'];
         }
 
         $record = MyActiveRecord::findBySql('');
 
-        if ($record = $record->one()) {
+        if (($record = $record->one()) !== null) {
             $flag = $record->flag;
             $flag = $record['flag'];
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type inference for ActiveQuery, resolving phpstan errors at the highest analysis level.
- **Documentation**
	- Updated the changelog to reflect recent bug fixes and enhancements.
- **Style**
	- Standardized PHPUnit assertions to use static method calls in tests.
	- Made conditional checks for ActiveRecord instances more explicit by comparing against null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->