### PR TITLE
fix: Enhance property reflection in `UserPropertiesClassReflectionExtension` to support identity class resolution and improve type inference for user component properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 - Enh #25: Add support for `PHPStan` Extension Installer (@samuelrajan747)
 - Enh #26: Add `PHPStan` extension installer instructions and improve `ServiceMap` configuration handling (@terabytesoftw)
-- Bug #27: Enhance error handling in `ServiceMap` for invalid configuration structures and add corresponding test cases (@terabytesoftw)
+- Bug #27: Fix error handling in `ServiceMap` for invalid configuration structures and add corresponding test cases (@terabytesoftw)
 - Bug #28: Refactor component handling in `ServiceMap` to improve variable naming and streamline logic (@terabytesoftw)
 - Enh #29: Enable strict rules and bleeding edge analysis, and update `README.md` with strict configuration examples (@terabytesoftw)
-- Bug #33: Enhance `ActiveRecordDynamicStaticMethodReturnTypeExtension` type inference for `ActiveQuery` support, and fix phpstan errors max lvl in tests (@terabytesoftw)
+- Bug #33: Fix `ActiveRecordDynamicStaticMethodReturnTypeExtension` type inference for `ActiveQuery` support, and fix phpstan errors max lvl in tests (@terabytesoftw)
+- Bug #34: Fix property reflection in `UserPropertiesClassReflectionExtension` to support `identityClass` resolution and improve type inference for `user` component properties (@terabytesoftw)
 
 ## 0.2.2 June 04, 2025
 

--- a/tests/ServiceMapTest.php
+++ b/tests/ServiceMapTest.php
@@ -12,6 +12,7 @@ use SplFileInfo;
 use SplObjectStorage;
 use SplStack;
 use yii\base\InvalidArgumentException;
+use yii\web\User;
 use yii2\extensions\phpstan\ServiceMap;
 use yii2\extensions\phpstan\tests\stub\MyActiveRecord;
 
@@ -110,6 +111,24 @@ final class ServiceMapTest extends TestCase
             MyActiveRecord::class,
             $serviceMap->getComponentClassById('customComponent'),
             'ServiceMap should resolve component id \'customComponent\' to \'MyActiveRecord::class\'.',
+        );
+        self::assertSame(
+            [
+                'identityClass' => 'yii2\extensions\phpstan\tests\stub\User',
+            ],
+            $serviceMap->getComponentDefinitionByClassName(User::class),
+            'ServiceMap should return the component definition for \'yii\web\User\'.',
+        );
+        self::assertNull(
+            $serviceMap->getComponentDefinitionByClassName('nonExistentComponent'),
+            'ServiceMap should return \'null\' for a \'non-existent\' component class.',
+        );
+        self::assertSame(
+            [
+                'identityClass' => 'yii2\extensions\phpstan\tests\stub\User',
+            ],
+            $serviceMap->getComponentDefinitionById('user'),
+            'ServiceMap should return the component definition for \'user\'.',
         );
         self::assertNull(
             $serviceMap->getComponentClassById('nonExistentComponent'),

--- a/tests/fixture/config.php
+++ b/tests/fixture/config.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use yii2\extensions\phpstan\tests\stub\MyActiveRecord;
+use yii2\extensions\phpstan\tests\stub\User;
 
 return [
     'components' => [
@@ -13,6 +14,10 @@ return [
             'class' => MyActiveRecord::class,
         ],
         'customInitializedComponent' => new MyActiveRecord(),
+        'user' => [
+            'class' => 'yii\web\User',
+            'identityClass' => User::class,
+        ],
     ],
     'container' => [
         'singletons' => [

--- a/tests/stub/MyController.php
+++ b/tests/stub/MyController.php
@@ -91,6 +91,7 @@ final class MyController extends Controller
         Yii::$app->response->data = Yii::$app->request->rawBody;
 
         $guest = Yii::$app->user->isGuest;
+        $id = Yii::$app->user->id;
 
         Yii::$app->user->identity->getAuthKey();
         Yii::$app->user->identity->doSomething();

--- a/tests/stub/User.php
+++ b/tests/stub/User.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\db\ActiveRecord;
+use yii\web\IdentityInterface;
+
+class User extends ActiveRecord implements IdentityInterface
+{
+    public static function findIdentity($id): IdentityInterface
+    {
+        return new static();
+    }
+
+    public static function findIdentityByAccessToken($token, $type = null): IdentityInterface
+    {
+        return new static();
+    }
+
+    public function getId(): int
+    {
+        return 1;
+    }
+
+    public function getAuthKey(): string
+    {
+        return '';
+    }
+
+    public function validateAuthKey($authKey): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
