### PR TITLE
fix: Correct exception message formatting in `ServiceMapServiceTest`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #35: Move config fixtures into `config` subdirectory (@terabytesoftw)
 - Enh #36: Update `ActiveQuery` and `ActiveRecord` dynamic return type extensions for improved type inference and error handling; remove deprecated `ActiveQueryObjectType` and `ActiveRecordObjectType` classes (@terabytesoftw)
 - Enh #37: Enhance `DI` container type inference and testing (@terabytesoftw)
+- Bug #38: Correct exception message formatting in `ServiceMapServiceTest` (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/tests/ServiceMapServiceTest.php
+++ b/tests/ServiceMapServiceTest.php
@@ -265,7 +265,9 @@ final class ServiceMapServiceTest extends TestCase
         $fixturePath = __DIR__ . "{$ds}fixture{$ds}config{$ds}singletons-unsupported-is-not-array.php";
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Configuration file '{$fixturePath}' must contain a valid 'container.singletons' 'array'.");
+        $this->expectExceptionMessage(
+            "Configuration file '{$fixturePath}' must contain a valid 'container.singletons' 'array'.",
+        );
 
         new ServiceMap($fixturePath);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to include a new bug fix entry for improved exception message formatting in tests.

- **Tests**
  - Adjusted the formatting of an exception message assertion in a test for better readability. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->