### PR TITLE
fix: Resolve `Container::get()` type inference for unconfigured classes in config (`ServiceMap`).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Enh #36: Update `ActiveQuery` and `ActiveRecord` dynamic return type extensions for improved type inference and error handling; remove deprecated `ActiveQueryObjectType` and `ActiveRecordObjectType` classes (@terabytesoftw)
 - Enh #37: Enhance `DI` container type inference and testing (@terabytesoftw)
 - Bug #38: Correct exception message formatting in `ServiceMapServiceTest` (@terabytesoftw)
-- Bug #39: Resolve `Container::get()` type inference for unconfigured classes in config (`ServiceMap`).
+- Bug #39: Resolve `Container::get()` type inference for unconfigured classes in config (`ServiceMap`) (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #36: Update `ActiveQuery` and `ActiveRecord` dynamic return type extensions for improved type inference and error handling; remove deprecated `ActiveQueryObjectType` and `ActiveRecordObjectType` classes (@terabytesoftw)
 - Enh #37: Enhance `DI` container type inference and testing (@terabytesoftw)
 - Bug #38: Correct exception message formatting in `ServiceMapServiceTest` (@terabytesoftw)
+- Bug #39: Resolve `Container::get()` type inference for unconfigured classes in config (`ServiceMap`).
 
 ## 0.2.3 June 09, 2025
 

--- a/tests/fixture/data/types/ContainerDynamicMethodReturnType.php
+++ b/tests/fixture/data/types/ContainerDynamicMethodReturnType.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace yii2\extensions\phpstan\tests\fixture\data\types;
 
+use Exception;
 use yii\base\InvalidConfigException;
-use yii\di\Container;
-use yii\di\NotInstantiableException;
+use yii\di\{Container, NotInstantiableException};
 use yii2\extensions\phpstan\tests\stub\MyActiveRecord;
 
 use function PHPStan\Testing\assertType;
@@ -27,6 +27,7 @@ use function random_int;
  * - Coverage for singleton, closure, and nested service definitions.
  * - Mixed type handling for unknown or dynamic service IDs.
  * - Parameterized instantiation and property assertions.
+ * - Priority testing: ServiceMap > Real classes > Unknown.
  * - Type assertions for class-string and string service identifiers.
  *
  * @copyright Copyright (C) 2023 Terabytesoftw.
@@ -141,6 +142,32 @@ final class ContainerDynamicMethodReturnType
         $unknown = $container->get('unknown-service');
 
         assertType('mixed', $unknown);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws NotInstantiableException if a class or service can't be instantiated.
+     */
+    public function testReturnServiceWhenGetRealClassNotInServiceMap(): void
+    {
+        $container = new Container();
+
+        $realClass = $container->get(Exception::class);
+
+        assertType('Exception', $realClass);
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     * @throws NotInstantiableException if a class or service can't be instantiated.
+     */
+    public function testReturnServiceWhenGetServiceMapWithStringConstant(): void
+    {
+        $container = new Container();
+
+        $instance = $container->get('yii2\extensions\phpstan\tests\stub\MyActiveRecord');
+
+        assertType('yii2\extensions\phpstan\tests\stub\MyActiveRecord', $instance);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved type inference for the Container::get() method, ensuring correct type detection when retrieving classes not explicitly configured as services.
- **Tests**
	- Added new tests to verify accurate type inference for both mapped and unmapped service retrieval scenarios.
- **Documentation**
	- Updated changelog to document the bug fix related to type inference in service retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->