### PR TITLE
test: Add tests for session property availability in `Console` and `Web` `Applications`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #40: Enhance `PHPStan` analysis for `Behavior` type inference and testing (@terabytesoftw)
 - Enh #41: Refactor `PHPDoc` comments for consistency and clarity (@terabytesoftw)
 - Bug #42: Move `ApplicationPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
+- Enh #43: Add tests for session property availability in `Console` and `Web` `Applications` (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/tests/fixture/data/property/ApplicationConsolePropertiesClassReflectionType.php
+++ b/tests/fixture/data/property/ApplicationConsolePropertiesClassReflectionType.php
@@ -121,4 +121,21 @@ final class ApplicationConsolePropertiesClassReflectionType
         assertType('string', Yii::$app->request->method);
         assertType('string', Yii::$app->response->format);
     }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     *
+     * Session property doesn't exist natively in Yii Console Application.
+     */
+    public function testSessionPropertyNotAvailableInConsoleApplication(): void
+    {
+        $app = new Application(['id' => 'testApp']);
+
+        Yii::$app = $app;
+
+        // @phpstan-ignore-next-line property.notFound
+        assertType('*ERROR*', $app->session);
+        // @phpstan-ignore-next-line property.notFound
+        assertType('*ERROR*', Yii::$app->session);
+    }
 }

--- a/tests/fixture/data/property/ApplicationConsolePropertiesClassReflectionType.php
+++ b/tests/fixture/data/property/ApplicationConsolePropertiesClassReflectionType.php
@@ -137,5 +137,7 @@ final class ApplicationConsolePropertiesClassReflectionType
         assertType('*ERROR*', $app->session);
         // @phpstan-ignore-next-line property.notFound
         assertType('*ERROR*', Yii::$app->session);
+
+        unset(Yii::$app);
     }
 }

--- a/tests/fixture/data/property/ApplicationWebPropertiesClassReflectionType.php
+++ b/tests/fixture/data/property/ApplicationWebPropertiesClassReflectionType.php
@@ -104,8 +104,11 @@ final class ApplicationWebPropertiesClassReflectionType
     {
         $app = new Application(['id' => 'testApp']);
 
+        Yii::$app = $app;
+
         assertType(Session::class, $app->session);
         assertType('string', $app->id);
+        assertType(Session::class, Yii::$app->session);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog to include details about new tests for session property availability in Console and Web Applications.

- **Tests**
  - Added a test to verify that the session property is not available in Console Applications.
  - Improved an existing test to ensure consistent type assertions for the session property in Web Applications, both locally and globally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->