### PR TITLE
refactor: Move `UserPropertiesClassReflectionExtension` to `property` directory and add testing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Enh #41: Refactor `PHPDoc` comments for consistency and clarity (@terabytesoftw)
 - Bug #42: Move `ApplicationPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
 - Enh #43: Add tests for session property availability in `Console` and `Web` `Applications` (@terabytesoftw)
+- bug #44: Move `UserPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Enh #41: Refactor `PHPDoc` comments for consistency and clarity (@terabytesoftw)
 - Bug #42: Move `ApplicationPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
 - Enh #43: Add tests for session property availability in `Console` and `Web` `Applications` (@terabytesoftw)
-- bug #44: Move `UserPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
+- Bug #44: Move `UserPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -14,6 +14,7 @@
         "PHPStan\\ShouldNotHappenException",
         "PHPStan\\TrinaryLogic",
         "PHPStan\\Type\\ArrayType",
+        "PHPStan\\Type\\BooleanType",
         "PHPStan\\Type\\Constant\\ConstantArrayType",
         "PHPStan\\Type\\Constant\\ConstantBooleanType",
         "PHPStan\\Type\\Constant\\ConstantStringType",

--- a/extension.neon
+++ b/extension.neon
@@ -27,6 +27,9 @@ services:
         class: yii2\extensions\phpstan\property\BehaviorPropertiesClassReflectionExtension
         tags: [phpstan.broker.propertiesClassReflectionExtension]
     -
+        class: yii2\extensions\phpstan\property\UserPropertiesClassReflectionExtension
+        tags: [phpstan.broker.propertiesClassReflectionExtension]
+    -
         class: yii2\extensions\phpstan\reflection\RequestMethodsClassReflectionExtension
         tags: [phpstan.broker.methodsClassReflectionExtension]
     -
@@ -34,9 +37,6 @@ services:
         tags: [phpstan.broker.propertiesClassReflectionExtension]
     -
         class: yii2\extensions\phpstan\reflection\ResponsePropertiesClassReflectionExtension
-        tags: [phpstan.broker.propertiesClassReflectionExtension]
-    -
-        class: yii2\extensions\phpstan\reflection\UserPropertiesClassReflectionExtension
         tags: [phpstan.broker.propertiesClassReflectionExtension]
     -
         class: yii2\extensions\phpstan\type\ActiveQueryDynamicMethodReturnTypeExtension

--- a/src/property/UserPropertiesClassReflectionExtension.php
+++ b/src/property/UserPropertiesClassReflectionExtension.php
@@ -13,8 +13,7 @@ use PHPStan\Reflection\{
 };
 use PHPStan\Reflection\Annotations\AnnotationsPropertiesClassReflectionExtension;
 use PHPStan\Reflection\Dummy\DummyPropertyReflection;
-use PHPStan\Type\Constant\ConstantBooleanType;
-use PHPStan\Type\{IntegerType, NullType, ObjectType, StringType, TypeCombinator};
+use PHPStan\Type\{BooleanType, IntegerType, NullType, ObjectType, StringType, TypeCombinator};
 use yii\web\User;
 use yii2\extensions\phpstan\reflection\ComponentPropertyReflection;
 use yii2\extensions\phpstan\ServiceMap;
@@ -104,7 +103,7 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
             if ($propertyName === 'isGuest') {
                 return new ComponentPropertyReflection(
                     new DummyPropertyReflection($propertyName),
-                    new ConstantBooleanType(true),
+                    new BooleanType(),
                     $classReflection,
                 );
             }

--- a/src/property/UserPropertiesClassReflectionExtension.php
+++ b/src/property/UserPropertiesClassReflectionExtension.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace yii2\extensions\phpstan\reflection;
+namespace yii2\extensions\phpstan\property;
 
 use PHPStan\Reflection\{
     ClassReflection,
@@ -16,29 +16,33 @@ use PHPStan\Reflection\Dummy\DummyPropertyReflection;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\{IntegerType, NullType, ObjectType, StringType, TypeCombinator};
 use yii\web\User;
+use yii2\extensions\phpstan\reflection\ComponentPropertyReflection;
 use yii2\extensions\phpstan\ServiceMap;
 
+use function in_array;
+use function is_string;
+
 /**
- * Provides property reflection for a Yii user component in PHPStan analysis.
+ * Provides property reflection for a Yii User component in PHPStan analysis.
  *
- * Integrates Yii's {@see User::identity] property and annotation-based property reflection into the user component
- * context, enabling accurate type inference and autocompletion for properties that are available on the user class.
+ * Integrates a Yii User component {@see User::identity} property and annotation-based property reflection into the user
+ * component context, enabling accurate type inference and autocompletion for properties that are available on the user
+ * class.
  *
  * This extension allows PHPStan to recognize and reflect the {@see User::identity} property on the Yii user instance,
  * as well as properties defined natively or via annotations, even if they aren't declared as native properties on the
  * user class.
  *
  * The implementation delegates property lookups to annotation-based property extensions and native property reflection,
- * while providing a custom reflection for the dynamic {@see User::identity] property.
+ * while providing a custom reflection for the dynamic {@see User::identity} property.
  *
  * Key features.
  * - Ensures compatibility with PHPStan strict analysis and autocompletion.
- * - Integrates annotation-based and native property reflection for the user component.
- * - Provides accurate type inference for the dynamic {@see User::identity] property.
- * - Supports dynamic and annotated property resolution for the user component.
+ * - Integrates annotation-based and native property reflection for the {@see User} component.
+ * - Provides accurate type inference for the dynamic {@see User::identity} property.
+ * - Supports dynamic and annotated property resolution for the {@see User} component.
  *
- * @see AnnotationsPropertiesClassReflectionExtension for annotation support.
- * @see ComponentPropertyReflection for dynamic property reflection.
+ * @see ComponentPropertyReflection for dynamic property reflection class.
  * @see PropertiesClassReflectionExtension for custom properties class reflection extension contract.
  *
  * @copyright Copyright (C) 2023 Terabytesoftw.
@@ -61,15 +65,16 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
     ) {}
 
     /**
-     * Retrieves the property reflection for a given property on the Yii user component.
+     * Retrieves the property reflection for a given property on the Yii User component.
      *
      * Resolves the property reflection for the specified property name by checking for the dynamic
-     * {@see User::identity} property, native properties, and annotation-based properties on the Yii user instance.
+     * {@see User::identity} property, native properties, and annotation-based properties on the Yii User instance.
      *
-     * For the 'identity' property, it resolves the type based on the configured identityClass in the user component.
+     * For the {@see User::identity} property, it resolves the type based on the configured {@see User::identityClass}
+     * in the {@see User} component.
      *
-     * @param ClassReflection $classReflection Class reflection instance for the Yii user component.
-     * @param string $propertyName Name of the property to retrieve.
+     * @param ClassReflection $classReflection Reflection of the class being analyzed.
+     * @param string $propertyName Name of the property to resolve.
      *
      * @throws MissingPropertyFromReflectionException if the property doesn't exist or can't be resolved.
      *
@@ -121,15 +126,16 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
     }
 
     /**
-     * Determines whether the specified property exists on the Yii user component.
+     * Determines whether the specified property exists on the Yii User component.
      *
-     * Checks for the existence of a property on the user instance by considering native properties,
-     * annotation-based properties, and the special 'identity' property.
+     * Checks for the existence of a property on the user instance by considering native properties, annotation-based
+     * properties, and the special {@see User::identity} property.
      *
-     * @param ClassReflection $classReflection Class reflection instance for the Yii user component.
-     * @param string $propertyName Name of the property to check for existence.
+     * @param ClassReflection $classReflection Reflection of the class being analyzed.
+     * @param string $propertyName Name of the property to resolve.
      *
-     * @return bool `true` if the property exists as a native, annotated, or identity property; `false` otherwise.
+     * @return bool `true` if the property exists as a native, annotated, or {@see User::identity} property; `false`
+     * otherwise.
      */
     public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
     {
@@ -146,12 +152,12 @@ final class UserPropertiesClassReflectionExtension implements PropertiesClassRef
     }
 
     /**
-     * Attempts to resolve the identity class from the user component configuration.
+     * Attempts to resolve the {@see User::identityClass} from the user component configuration.
      *
-     * This method tries to determine the identityClass configured for the user component
-     * by looking at the service map's user component configuration.
+     * This method tries to determine the {@see User::identityClass} configured for the user component by looking at the
+     * service map's user component configuration.
      *
-     * @return string|null The fully qualified identity class name, or null if not found.
+     * @return string|null Fully qualified {@see User::identityClass} name, or `null` if not found.
      */
     private function getIdentityClass(): string|null
     {

--- a/tests/fixture/data/property/UserPropertiesClassReflectionType.php
+++ b/tests/fixture/data/property/UserPropertiesClassReflectionType.php
@@ -30,7 +30,7 @@ final class UserPropertiesClassReflectionType
 {
     public function testReturnBooleanFromIsGuestProperty(): void
     {
-        assertType('true', Yii::$app->user->isGuest);
+        assertType('bool', Yii::$app->user->isGuest);
     }
 
     public function testReturnBooleanOrNullFromValidateAuthKeyMethod(): void

--- a/tests/fixture/data/property/UserPropertiesClassReflectionType.php
+++ b/tests/fixture/data/property/UserPropertiesClassReflectionType.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\fixture\data\property;
+
+use Yii;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Data provider for property reflection of Yii User component in PHPStan analysis.
+ *
+ * Validates type inference and return types for properties provided by the Yii User component, ensuring that PHPStan
+ * correctly recognizes and infers types for available properties as if they were natively declared on the user object.
+ *
+ * These tests cover scenarios including direct property access, identity and guest checks, parameterized properties,
+ * and shared property resolution, verifying that type assertions match the expected return types for each case.
+ *
+ * Key features.
+ * - Coverage for identity, guest, and parameterized properties.
+ * - Ensures compatibility with PHPStan property reflection for Yii user component.
+ * - Type assertion for native and user-provided properties.
+ * - Validates correct type inference for all supported property types.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class UserPropertiesClassReflectionType
+{
+    public function testReturnBooleanFromIsGuestProperty(): void
+    {
+        assertType('true', Yii::$app->user->isGuest);
+    }
+
+    public function testReturnBooleanOrNullFromValidateAuthKeyMethod(): void
+    {
+        assertType('bool|null', Yii::$app->user->identity->validateAuthKey('123abc'));
+    }
+
+    public function testReturnIdentityFromIdentityProperty(): void
+    {
+        assertType('yii2\extensions\phpstan\tests\stub\User', Yii::$app->user->identity);
+    }
+
+    public function testReturnIdentityInterfaceOrNullFromFindIdentityByAccessTokenMethod(): void
+    {
+        assertType('yii\web\IdentityInterface|null', Yii::$app->user->identity::findIdentityByAccessToken('123abc'));
+    }
+
+    public function testReturnIdentityInterfaceOrNullFromFindIdentityMethod(): void
+    {
+        assertType('yii\web\IdentityInterface|null', Yii::$app->user->identity::findIdentity(1));
+    }
+
+    public function testReturnStringFromEmailProperty(): void
+    {
+        assertType('string', Yii::$app->user->identity->email);
+    }
+
+    public function testReturnStringFromNameProperty(): void
+    {
+        assertType('string', Yii::$app->user->identity->name);
+    }
+
+    public function testReturnStringFromReturnUrlProperty(): void
+    {
+        assertType('string', Yii::$app->user->returnUrl);
+    }
+
+    public function testReturnStringOrNullFromGetAuthKeyMethod(): void
+    {
+        assertType('string|null', Yii::$app->user->identity->getAuthKey());
+    }
+
+    public function testReturnUnionFromGetIdMethod(): void
+    {
+        assertType('int|string|null', Yii::$app->user->getId());
+    }
+
+    public function testReturnUnionFromIdProperty(): void
+    {
+        assertType('int|string|null', Yii::$app->user->id);
+    }
+}

--- a/tests/property/UserPropertiesClassReflectionExtensionTest.php
+++ b/tests/property/UserPropertiesClassReflectionExtensionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\property;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test suite for type inference of property reflection in a Yii User component for PHPStan analysis.
+ *
+ * Validates that PHPStan correctly infers types for properties provided by the Yii User component, using fixture-based
+ * assertions for direct property access, parameterized properties, and shared property resolution.
+ *
+ * The test class loads type assertions from a fixture file and delegates checks to the parent
+ * {@see TypeInferenceTestCase}, ensuring that extension logic for {@see UserPropertiesClassReflectionExtension} is
+ * robust and consistent with expected behavior.
+ *
+ * Key features.
+ * - Ensures compatibility with PHPStan extension configuration.
+ * - Loads and executes type assertions from a dedicated fixture file.
+ * - Uses PHPUnit DataProvider for parameterized test execution.
+ * - Validates type inference for native and user-provided properties.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class UserPropertiesClassReflectionExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        $directory = dirname(__DIR__);
+
+        yield from self::gatherAssertTypes("{$directory}/fixture/data/property/UserPropertiesClassReflectionType.php");
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [dirname(__DIR__) . '/extension-tests.neon'];
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}

--- a/tests/stub/User.php
+++ b/tests/stub/User.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii2\extensions\phpstan\tests\stub;
 
 use yii\db\ActiveRecord;
+use yii\web\IdentityInterface;
 
 /**
  * User ActiveRecord model for testing property and rule definitions.
@@ -15,23 +16,38 @@ use yii\db\ActiveRecord;
  * This class is used in PHPStan and static analysis scenarios to validate correct type inference for property access
  * and rule configuration in Yii Active Record models.
  *
- * Key features.
- * - Declares public properties {@see $id}, {@see $name}, and {@see $email} for type assertion tests.
- * - Defines {@see rules()} for property validation and type constraints.
- * - Implements {@see tableName()} for table mapping in test scenarios.
- *
- * @property int $id
  * @property string $name
  * @property string $email
  *
  * @copyright Copyright (C) 2023 Terabytesoftw.
  * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
  */
-class User extends ActiveRecord
+final class User extends ActiveRecord implements IdentityInterface
 {
-    public int $id = 1;
-    public string $name = 'John Doe';
-    public string $email = 'john@example.com';
+    public static function findIdentity($id)
+    {
+        return YII_ENV_DEV ? new self() : null;
+    }
+
+    public static function findIdentityByAccessToken($token, $type = null)
+    {
+        return YII_ENV_DEV ? new self() : null;
+    }
+
+    public function getId()
+    {
+        return YII_ENV_DEV ? 'dev-id' : 1;
+    }
+
+    public function getAuthKey()
+    {
+        return YII_ENV_DEV ? 'dev-auth' : null;
+    }
+
+    public function validateAuthKey($authKey)
+    {
+        return true;
+    }
 
     public static function tableName(): string
     {

--- a/tests/stub/User.php
+++ b/tests/stub/User.php
@@ -25,14 +25,14 @@ use yii\web\IdentityInterface;
  */
 final class User extends ActiveRecord implements IdentityInterface
 {
-    public static function findIdentity($id)
+    public static function findIdentity($id): IdentityInterface|null
     {
-        return YII_ENV_DEV ? new self() : null;
+        return \defined('YII_ENV_DEV') && YII_ENV_DEV ? new self() : null;
     }
 
-    public static function findIdentityByAccessToken($token, $type = null)
+    public static function findIdentityByAccessToken($token, $type = null): IdentityInterface|null
     {
-        return YII_ENV_DEV ? new self() : null;
+        return \defined('YII_ENV_DEV') && YII_ENV_DEV ? new self() : null;
     }
 
     public function getId()
@@ -40,14 +40,14 @@ final class User extends ActiveRecord implements IdentityInterface
         return YII_ENV_DEV ? 'dev-id' : 1;
     }
 
-    public function getAuthKey()
+    public function getAuthKey(): string|null
     {
         return YII_ENV_DEV ? 'dev-auth' : null;
     }
 
-    public function validateAuthKey($authKey)
+    public function validateAuthKey($authKey): bool|null
     {
-        return true;
+        return YII_ENV_DEV ? true : null;
     }
 
     public static function tableName(): string

--- a/tests/stub/User.php
+++ b/tests/stub/User.php
@@ -16,6 +16,7 @@ use yii\web\IdentityInterface;
  * This class is used in PHPStan and static analysis scenarios to validate correct type inference for property access
  * and rule configuration in Yii Active Record models.
  *
+ * @property int $id
  * @property string $name
  * @property string $email
  *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated changelog to document relocation of user property reflection extension and related tests.

- **Documentation**
  - Improved and clarified PHPDoc comments for the user property reflection extension, including consistent references and more precise descriptions.

- **Tests**
  - Added comprehensive tests to verify type inference for Yii User component properties and methods.
  - Enhanced test coverage by introducing new test classes and updating test stubs for the User component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->