### PR TITLE
feat: Add `ActiveRecordGetAttributeDynamicMethodReturnTypeExtension` to provide precise type inference for `getAttribute()` method calls based on PHPDoc annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bug #44: Move `UserPropertiesClassReflectionExtension` to `property` directory and add testing (@terabytesoftw)
 - Bug #45: Improve `ServiceMap` configuration for application types (`Base`, `Console`, `Web`) (@terabytesoftw)
 - Bug #46: Update `README.md` to enhance clarity and structure of `docs/installation.md`, `docs/configuration.md` and `docs/examples.md` (@terabytesoftw)
+- Enh #47: Add `ActiveRecordGetAttributeDynamicMethodReturnTypeExtension` to provide precise type inference for `getAttribute()` method calls based on PHPDoc annotations (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ composer require --dev yii2-extensions/phpstan
 - Array/object result type inference based on `asArray()` usage.
 - Dynamic return type inference for `find()`, `findOne()`, `findAll()` methods.
 - Generic type support for `ActiveQuery<Model>` with proper chaining.
+- Hierarchical type resolution: model properties take precedence over behavior properties.
+- Precise type inference for `getAttribute()` method calls based on PHPDoc annotations.
+- Property type resolution from both model classes and attached behaviors.
 - Relation methods (`hasOne()`, `hasMany()`) with accurate return types.
+- Support for behavior property definitions through ServiceMap integration.
 
 ✅ **Application Component Resolution**
 - Automatic type inference for `Yii::$app->component` access.
@@ -119,6 +123,12 @@ $query = User::find()->where(['active' => 1])->orderBy('name');
 
 // ✅ Array results properly typed as array{id: int, name: string}[]
 $userData = User::find()->asArray()->all();
+
+// ✅ Properly typed based on model property annotations string
+$userName = $user->getAttribute('name');
+
+// ✅ Behavior property resolution string
+$slug = $user->getAttribute('slug');
 ```
 
 ### Application Components

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,6 +216,9 @@ For accurate type inference, behaviors should define their properties using PHPD
 ```php
 <?php
 
+use yii\base\Behavior;
+use yii\db\ActiveRecord;
+
 /**
  * @template T of ActiveRecord
  * @extends Behavior<T>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -209,6 +209,25 @@ return [
 ];
 ```
 
+### Behavior PHPDoc Requirements
+
+For accurate type inference, behaviors should define their properties using PHPDoc.
+
+```php
+<?php
+
+/**
+ * @template T of ActiveRecord
+ * @extends Behavior<T>
+ *
+ * @property int $depth
+ * @property int $lft
+ * @property int $rgt
+ * @property int|false $tree
+ */
+class NestedSetsBehavior extends Behavior {}
+```
+
 ### Container Configuration
 
 Define DI container services.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -557,6 +557,9 @@ class ServiceFactory
 ```php
 <?php
 
+use yii\behaviors\Behavior;
+use yii\db\ActiveRecord;
+
 /**
  * Behavior with PHPDoc property definitions.
  * 

--- a/extension.neon
+++ b/extension.neon
@@ -39,6 +39,9 @@ services:
         class: yii2\extensions\phpstan\type\ActiveRecordDynamicStaticMethodReturnTypeExtension
         tags: [phpstan.broker.dynamicStaticMethodReturnTypeExtension]
     -
+        class: yii2\extensions\phpstan\type\ActiveRecordGetAttributeDynamicMethodReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
         class: yii2\extensions\phpstan\type\ContainerDynamicMethodReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
     -

--- a/src/type/ActiveRecordGetAttributeDynamicMethodReturnTypeExtension.php
+++ b/src/type/ActiveRecordGetAttributeDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\type;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\{ClassReflection, MethodReflection, ReflectionProvider};
+use PHPStan\Type\{DynamicMethodReturnTypeExtension, FileTypeMapper, MixedType, Type};
+use Throwable;
+use yii\db\ActiveRecord;
+use yii2\extensions\phpstan\ServiceMap;
+
+use function count;
+
+/**
+ * Provides dynamic return type extension for Yii Active Record {@see ActiveRecord::getAttribute()} method in PHPStan
+ * analysis.
+ *
+ * Enables PHPStan to infer precise return types for {@see ActiveRecord::getAttribute()} method calls by analyzing the
+ * attribute name and extracting type information from PHPDoc property annotations in the model class and its attached
+ * behaviors.
+ *
+ * This extension examines the constant string argument passed to {@see ActiveRecord::getAttribute()} and resolves the
+ * corresponding property type from the model's PHPDoc `@property` tags or from behaviors registered through the
+ * {@see ServiceMap}.
+ *
+ * The type resolution follows a hierarchical approach, first checking the model class's own PHPDoc annotations, then
+ * searching through attached behaviors' property definitions to provide comprehensive type coverage for dynamic
+ * attribute access.
+ *
+ * Key features.
+ * - Attribute name validation from constant string arguments in method calls.
+ * - Behavior integration through {@see ServiceMap} for comprehensive property type resolution.
+ * - Dynamic type inference for {@see ActiveRecord::getAttribute()} method calls.
+ * - Fallback to {@see MixedType} for unknown or non-constant attribute names.
+ * - Integration with PHPStan file type mapper for accurate PHPDoc parsing.
+ * - PHPDoc property tag extraction from model classes and behaviors.
+ *
+ * @see ActiveRecord for ActiveRecord API details.
+ * @see DynamicMethodReturnTypeExtension for PHPStan dynamic return type extension contract.
+ * @see ServiceMap for service and component map for Yii Application static analysis.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ActiveRecordGetAttributeDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * Creates a new instance of the {@see ActiveRecordGetAttributeDynamicMethodReturnTypeExtension} class.
+     *
+     * @param ReflectionProvider $reflectionProvider Reflection provider for class and property lookups.
+     * @param FileTypeMapper $fileTypeMapper File type mapper for resolving PHPDoc types.
+     * @param ServiceMap $serviceMap Service and component map for Yii Application static analysis.
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly FileTypeMapper $fileTypeMapper,
+        private readonly ServiceMap $serviceMap,
+    ) {}
+
+    /**
+     * Returns the class name for which this dynamic method return type extension applies.
+     *
+     * Specifies the fully qualified class name of the supported class, enabling PHPStan to associate this extension
+     * with method calls on the {@see ActiveRecord} base class and its subclasses.
+     *
+     * This method is essential for registering the extension with PHPStan type system, ensuring that dynamic method
+     * return type inference is applied to the correct class hierarchy during static analysis and IDE autocompletion.
+     *
+     * @return string Fully qualified class name of the supported {@see ActiveRecord} class.
+     *
+     * @phpstan-return class-string
+     */
+    public function getClass(): string
+    {
+        return ActiveRecord::class;
+    }
+
+    /**
+     * Infers the return type for {@see ActiveRecord::getAttribute()} method calls.
+     *
+     * Resolves the return type for {@see ActiveRecord::getAttribute()} method by analyzing the attribute name argument
+     * and extracting type information from PHPDoc property annotations in the model class and its attached behaviors.
+     *
+     * This enables precise type inference for static analysis and IDE autocompletion when accessing ActiveRecord
+     * attributes dynamically.
+     *
+     * The method validates that the first argument is a constant string representing the attribute name, then searches
+     * for the corresponding property type in the model's PHPDoc `@property` tags. If not found in the model class, it
+     * searches through attached behaviors' property definitions via the {@see ServiceMap}.
+     *
+     * @param MethodReflection $methodReflection Reflection instance for the method being analyzed.
+     * @param MethodCall $methodCall AST node for the method call expression.
+     * @param Scope $scope PHPStan analysis scope for type resolution.
+     *
+     * @return Type Inferred return type for the {@see ActiveRecord::getAttribute()} call, or {@see MixedType} if the
+     * attribute type can't be determined.
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): Type {
+        if (isset($methodCall->args[0]) === false || $methodCall->args[0]::class !== Arg::class) {
+            return new MixedType();
+        }
+
+        $argType = $scope->getType($methodCall->args[0]->value);
+        $constantStrings = $argType->getConstantStrings();
+
+        if (count($constantStrings) !== 1) {
+            return new MixedType();
+        }
+
+        $attributeName = $constantStrings[0]->getValue();
+        $calledOnType = $scope->getType($methodCall->var);
+        $classNames = $calledOnType->getObjectClassNames();
+
+        if (count($classNames) !== 1) {
+            return new MixedType();
+        }
+
+        $className = $classNames[0];
+
+        if ($this->reflectionProvider->hasClass($className) === false) {
+            return new MixedType();
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+        $propertyType = $this->getPropertyTypeFromPhpDoc($classReflection, $attributeName);
+
+        if ($propertyType !== null) {
+            return $propertyType;
+        }
+
+        $propertyType = $this->getPropertyTypeFromBehaviors($className, $attributeName);
+
+        return $propertyType ?? new MixedType();
+    }
+
+    /**
+     * Checks if the given method is supported for dynamic return type inference.
+     *
+     * Determines support by verifying if the method name is {@see ActiveRecord::getAttribute()}.
+     *
+     * This ensures that only the {@see ActiveRecord::getAttribute()} method with dynamic return types is handled by
+     * this extension for precise type inference during static analysis.
+     *
+     * @param MethodReflection $methodReflection Reflection instance for the method being analyzed.
+     *
+     * @return bool `true` if the method is {@see ActiveRecord::getAttribute()}; `false` otherwise.
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getAttribute';
+    }
+
+    /**
+     * Extracts the type of a specific property from PHPDoc annotations.
+     *
+     * Parses the PHPDoc comment of the provided {@see ClassReflection} to retrieve property tags and their associated
+     * types for the specified property name.
+     *
+     * This enables precise type inference for model properties in static analysis by examining the `@property` tags
+     * documented in the class's PHPDoc block and resolving their types using the file type mapper.
+     *
+     * The method handles file name validation, doc comment extraction, and PHPDoc parsing with error handling to ensure
+     * robust type resolution for dynamic attribute access in {@see ActiveRecord::getAttribute()} calls.
+     *
+     * Only properties explicitly documented in the PHPDoc block with `@property` tags are considered for type
+     * extraction.
+     *
+     * @param ClassReflection $classReflection Reflection of the class being analyzed.
+     * @param string $propertyName Name of the property to resolve.
+     *
+     * @return Type|null Resolved property type if found in PHPDoc annotations, `null` if not available or extraction
+     * fails.
+     */
+    private function getPropertyTypeFromPhpDoc(ClassReflection $classReflection, string $propertyName): Type|null
+    {
+        $fileName = $classReflection->getFileName();
+
+        if ($fileName === null) {
+            return null;
+        }
+
+        $docComment = $classReflection->getNativeReflection()->getDocComment();
+
+        if ($docComment === false) {
+            return null;
+        }
+
+        try {
+            $resolvedPhpDoc = $this->fileTypeMapper->getResolvedPhpDoc(
+                $fileName,
+                $classReflection->getName(),
+                null,
+                null,
+                docComment: $docComment,
+            );
+
+            $propertyTags = $resolvedPhpDoc->getPropertyTags();
+
+            if (isset($propertyTags[$propertyName])) {
+                return $propertyTags[$propertyName]->getReadableType();
+            }
+
+            return null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Searches for property types in attached behaviors' PHPDoc annotations.
+     *
+     * Iterates through all behaviors registered for the specified model class via the {@see ServiceMap} and examines
+     * their PHPDoc property annotations to locate the requested attribute type.
+     *
+     * This method provides comprehensive type resolution by extending the search beyond the model class itself to
+     * include properties defined in attached behaviors, enabling accurate type inference for dynamic attributes that
+     * are provided by behaviors rather than the model directly.
+     *
+     * The search process validates each behavior class existence, creates reflection instances, and delegates to
+     * {@see getPropertyTypeFromPhpDoc()} for actual property type extraction from behavior PHPDoc blocks.
+     *
+     * This method is essential for complete type coverage in {@see ActiveRecord::getAttribute()} calls when
+     * attributes are defined in behaviors attached to the model class.
+     *
+     * @param string $className Fully qualified class name to check.
+     * @param string $attributeName The attribute name to search for.
+     *
+     * @return Type|null Property type if found in any behavior, `null` if not found or behavior classes are
+     * unavailable.
+     */
+    private function getPropertyTypeFromBehaviors(string $className, string $attributeName): Type|null
+    {
+        $behaviors = $this->serviceMap->getBehaviorsByClassName($className);
+
+        foreach ($behaviors as $behaviorClass) {
+            if ($this->reflectionProvider->hasClass($behaviorClass)) {
+                $behaviorReflection = $this->reflectionProvider->getClass($behaviorClass);
+
+                $propertyType = $this->getPropertyTypeFromPhpDoc($behaviorReflection, $attributeName);
+
+                if ($propertyType !== null) {
+                    return $propertyType;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/config/config.php
+++ b/tests/config/config.php
@@ -3,10 +3,31 @@
 declare(strict_types=1);
 
 use yii\web\View;
-use yii2\extensions\phpstan\tests\stub\{BehaviorOne, BehaviorTwo, MyActiveRecord, MyComponent, User};
+use yii2\extensions\phpstan\tests\stub\{
+    BehaviorOne,
+    BehaviorTwo,
+    ModelWithConflictingProperty,
+    ModelWithMultipleBehaviors,
+    MyActiveRecord,
+    MyComponent,
+    NestedSetsBehavior,
+    NestedSetsModel,
+    SlugBehavior,
+    User,
+};
 
 return [
     'behaviors' => [
+        ModelWithConflictingProperty::class => [
+            NestedSetsBehavior::class,
+        ],
+        ModelWithMultipleBehaviors::class => [
+            NestedSetsBehavior::class,
+            SlugBehavior::class,
+        ],
+        NestedSetsModel::class => [
+            NestedSetsBehavior::class,
+        ],
         MyComponent::class => [
             BehaviorOne::class,
             BehaviorTwo::class,
@@ -32,35 +53,35 @@ return [
         ],
     ],
     'container' => [
-        'singletons' => [
-            'singleton-string' => MyActiveRecord::class,
-            'singleton-closure' => static function (): SplStack {
-                return new SplStack();
-            },
-            'singleton-service' => [
-                'class' => SplObjectStorage::class,
-            ],
-            'singleton-nested-service-class' => [
-                [
-                    'class' => SplFileInfo::class,
-                ],
-            ],
-        ],
         'definitions' => [
             'closure' => static function (): SplStack {
                 return new SplStack();
             },
-            'service' => [
-                'class' => SplObjectStorage::class,
+            MyActiveRecord::class => [
+                'flag' => 'foo',
             ],
             'nested-service-class' => [
                 [
                     'class' => SplFileInfo::class,
                 ],
             ],
-            MyActiveRecord::class => [
-                'flag' => 'foo',
+            'service' => [
+                'class' => SplObjectStorage::class,
             ],
+        ],
+        'singletons' => [
+            'singleton-closure' => static function (): SplStack {
+                return new SplStack();
+            },
+            'singleton-nested-service-class' => [
+                [
+                    'class' => SplFileInfo::class,
+                ],
+            ],
+            'singleton-service' => [
+                'class' => SplObjectStorage::class,
+            ],
+            'singleton-string' => MyActiveRecord::class,
         ],
     ],
 ];

--- a/tests/data/type/ActiveRecordGetAttributeDynamicMethodReturnType.php
+++ b/tests/data/type/ActiveRecordGetAttributeDynamicMethodReturnType.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\data\type;
+
+use yii\db\ActiveRecord;
+use yii2\extensions\phpstan\tests\stub\{
+    ModelWithConflictingProperty,
+    ModelWithMultipleBehaviors,
+    NestedSetsModel,
+    Post,
+};
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Test suite for dynamic return types of {@see ActiveRecord::getAttribute} method in Yii Active Record scenarios.
+ *
+ * Validates type inference and return types for {@see ActiveRecord::getAttribute} method when used with custom
+ * {@see ActiveRecord} implementations that include behaviors with property definitions and PHPDoc annotations, ensuring
+ * proper type resolution for model properties and behavior-defined attributes.
+ *
+ * These tests ensure that PHPStan correctly infers the result types for {@see ActiveRecord::getAttribute} calls based
+ * on model property annotations, behavior property definitions, and precedence rules when both model and behavior
+ * define the same property name.
+ *
+ * The test suite validates the type system's ability to distinguish between model-defined properties and behavior-added
+ * properties, ensuring that model property types take precedence over behavior property types when conflicts occur.
+ *
+ * Test coverage.
+ * - Behavior property type inference for multiple behaviors with different property types.
+ * - Model property type inference from PHPDoc annotations.
+ * - Multiple behavior property handling with different return types.
+ * - Precedence rules for conflicting property names between models and behaviors.
+ * - Type inference for unknown attributes (fallback to mixed type).
+ * - Type safety validation for {@see ActiveRecord::getAttribute} with known and unknown properties.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ActiveRecordGetAttributeDynamicMethodReturnType
+{
+    public function testReturnIntAndStringWhenGetAttributeWithMultipleBehaviors(): void
+    {
+        $model = new ModelWithMultipleBehaviors();
+
+        assertType('int', $model->getAttribute('lft'));
+        assertType('string', $model->getAttribute('slug'));
+    }
+
+    public function testReturnIntWhenGetAttributeWithBehaviorPhpDoc(): void
+    {
+        $model = new NestedSetsModel();
+
+        assertType('int', $model->getAttribute('lft'));
+        assertType('int', $model->getAttribute('rgt'));
+        assertType('int', $model->getAttribute('depth'));
+    }
+
+    public function testReturnMixedWhenGetAttributeWithBehaviorPhpDoc(): void
+    {
+        $model = new NestedSetsModel();
+
+        assertType('mixed', $model->getAttribute('unknown_attribute'));
+    }
+
+    public function testReturnMixedWhenGetAttributeWithModelPhpDoc(): void
+    {
+        $post = new Post();
+
+        assertType('mixed', $post->getAttribute('unknown_attribute'));
+    }
+
+    public function testReturnStringWhenGetAttributeWithModelPhpDoc(): void
+    {
+        $post = new Post();
+
+        assertType('string', $post->getAttribute('title'));
+        assertType('string', $post->getAttribute('content'));
+    }
+
+    public function testReturnStringWhenGetAttributeWithModelPhpDocTakesPrecedenceOverBehavior(): void
+    {
+        $model = new ModelWithConflictingProperty();
+
+        assertType('string', $model->getAttribute('lft'));
+    }
+}

--- a/tests/stub/ModelWithConflictingProperty.php
+++ b/tests/stub/ModelWithConflictingProperty.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\db\ActiveRecord;
+
+/**
+ * Active Record model for testing property conflicts between model and behavior definitions.
+ *
+ * This class demonstrates a scenario where a model defines a property that conflicts with a property defined in an
+ * attached behavior. The model defines a `lft` property as string while the {@see NestedSetsBehavior} defines the same
+ * property as int, creating a type conflict for static analysis tools.
+ *
+ * This model is specifically designed for testing PHPStan extensions and their ability to handle property conflicts
+ * between behaviors and model declarations, ensuring proper type resolution and conflict detection in Yii2
+ * applications.
+ *
+ * The conflict occurs when the behavior's property type differs from the model's declared property type, which requires
+ * careful handling by static analysis tools to provide accurate type information.
+ *
+ * Key features:
+ * - Behavior attachment with conflicting property types.
+ * - Property conflict demonstration for testing purposes.
+ * - Static analysis validation for type resolution.
+ * - Table mapping with conflict_test table.
+ * - Type conflict between string and int for lft property.
+ *
+ * @property string $lft
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ModelWithConflictingProperty extends ActiveRecord
+{
+    public function behaviors(): array
+    {
+        return [
+            'nestedSets' => [
+                'class' => NestedSetsBehavior::class,
+            ],
+        ];
+    }
+
+    public static function tableName(): string
+    {
+        return 'conflict_test';
+    }
+}

--- a/tests/stub/ModelWithMultipleBehaviors.php
+++ b/tests/stub/ModelWithMultipleBehaviors.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\db\ActiveRecord;
+
+/**
+ * Active Record model for testing multiple behavior attachments and property aggregation.
+ *
+ * This class demonstrates a scenario where a model attaches multiple behaviors simultaneously, each contributing
+ * different properties and methods to the model instance. The model combines {@see NestedSetsBehavior} for tree
+ * structure operations and {@see SlugBehavior} for URL-friendly slug generation.
+ *
+ * This model is specifically designed for testing PHPStan extensions and their ability to handle multiple behavior
+ * attachments, ensuring proper property and method resolution when behaviors are combined in Yii2 applications.
+ *
+ * The behaviors work independently but are managed together by the model, allowing testing of property aggregation,
+ * method resolution, and potential conflicts between multiple behavior implementations.
+ *
+ * Key features:
+ * - Multiple behavior attachment with property aggregation.
+ * - Nested sets functionality for hierarchical data structures.
+ * - Property resolution testing for multiple behaviors.
+ * - Slug generation capability for URL-friendly identifiers.
+ * - Static analysis validation for behavior combination.
+ * - Table mapping with multiple_behaviors_test table.
+ *
+ * @property int $depth
+ * @property int $lft
+ * @property int $rgt
+ * @property string $slug
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ModelWithMultipleBehaviors extends ActiveRecord
+{
+    public function behaviors(): array
+    {
+        return [
+            'nestedSets' => [
+                'class' => NestedSetsBehavior::class,
+            ],
+            'slug' => [
+                'class' => SlugBehavior::class,
+            ],
+        ];
+    }
+
+    public static function tableName(): string
+    {
+        return 'multiple_behaviors_test';
+    }
+}

--- a/tests/stub/NestedSetsBehavior.php
+++ b/tests/stub/NestedSetsBehavior.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\base\Behavior;
+use yii\db\ActiveRecord;
+
+/**
+ * Provides nested sets functionality for Active Record models via a Yii behavior mechanism.
+ *
+ * This class defines properties and methods for implementing nested sets model operations on Active Record instances,
+ * enabling hierarchical data structure management at runtime. It demonstrates the use of typed properties for tree
+ * structure manipulation in Yii Applications.
+ *
+ * The nested sets model uses three integer properties to represent hierarchical relationships: depth for the node level
+ * in the tree, lft for the left boundary, and rgt for the right boundary of the node's subtree.
+ *
+ * This behavior is specifically designed for testing PHPStan extensions and their ability to handle behavior property
+ * definitions, ensuring proper type resolution and property access in Active Record models with attached behaviors.
+ *
+ * Key features.
+ * - Depth property for representing node level in hierarchical structures.
+ * - Left and right boundary properties for nested sets model implementation.
+ * - Property type definitions for static analysis and IDE autocompletion.
+ * - Type-safe integration with Active Record models.
+ *
+ * @template T of ActiveRecord
+ * @extends Behavior<T>
+ *
+ * @property int $depth
+ * @property int $lft
+ * @property int $rgt
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NestedSetsBehavior extends Behavior {}

--- a/tests/stub/NestedSetsModel.php
+++ b/tests/stub/NestedSetsModel.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\db\ActiveRecord;
+
+/**
+ * Active Record model for testing nested sets behavior attachment and property resolution.
+ *
+ * This class demonstrates a scenario where a model attaches the {@see NestedSetsBehavior} to enable hierarchical data
+ * structure operations. The model provides tree structure functionality through the behavior's properties and methods,
+ * allowing for nested sets model implementation on Active Record instances.
+ *
+ * This model is specifically designed for testing PHPStan extensions and their ability to handle behavior property
+ * resolution, ensuring proper type inference and property access when behaviors are attached to Yii Active Record
+ * models.
+ *
+ * The nested sets behavior provides three integer properties (depth, lft, rgt) that are used to represent hierarchical
+ * relationships in database tables, enabling efficient tree structure queries and operations.
+ *
+ * Key features:
+ * - Behavior attachment for hierarchical data structures.
+ * - Nested sets model functionality for tree operations.
+ * - Property resolution testing for behavior integration.
+ * - Static analysis validation for behavior property access.
+ * - Table mapping with nested_sets_test table.
+ *
+ * @property int $depth
+ * @property int $lft
+ * @property int $rgt
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class NestedSetsModel extends ActiveRecord
+{
+    public function behaviors(): array
+    {
+        return [
+            'nestedSets' => [
+                'class' => NestedSetsBehavior::class,
+            ],
+        ];
+    }
+
+    public static function tableName(): string
+    {
+        return 'nested_sets_test';
+    }
+}

--- a/tests/stub/SlugBehavior.php
+++ b/tests/stub/SlugBehavior.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\stub;
+
+use yii\base\Behavior;
+use yii\db\ActiveRecord;
+
+/**
+ * Provides URL-friendly slug generation functionality for Active Record models via a Yii behavior mechanism.
+ *
+ * This class defines a slug property to be attached to Active Record components, enabling automatic generation of
+ * URL-friendly identifiers at runtime. It demonstrates the use of typed properties for string-based identifier
+ * management in Yii Applications.
+ *
+ * The slug property is designed to store URL-safe string representations of model data, typically generated from
+ * title, name, or other human-readable fields to create SEO-friendly URLs and consistent identifier patterns.
+ *
+ * This behavior is specifically designed for testing PHPStan extensions and their ability to handle behavior property
+ * definitions, ensuring proper type resolution and property access in Active Record models with attached behaviors.
+ *
+ * Key features.
+ * - Property type definitions for static analysis and IDE autocompletion.
+ * - Slug property for URL-friendly identifier generation.
+ * - Type-safe integration with Active Record models.
+ *
+ * @template T of ActiveRecord
+ * @extends Behavior<T>
+ *
+ * @property string $slug
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class SlugBehavior extends Behavior {}

--- a/tests/type/ActiveRecordGetAttributeDynamicMethodReturnTypeExtensionTest.php
+++ b/tests/type/ActiveRecordGetAttributeDynamicMethodReturnTypeExtensionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test suite for type inference of dynamic return types in {@see ActiveRecord::getAttribute()} method calls.
+ *
+ * Validates that PHPStan correctly infers return types for {@see ActiveRecord::getAttribute()} method calls through the
+ * custom PHPStan extension, using fixture-based assertions for model property access, behavior property resolution, and
+ * type precedence scenarios.
+ *
+ * The test class loads type assertions from a fixture file and delegates checks to the parent
+ * {@see TypeInferenceTestCase}, ensuring that extension logic for {@see ActiveRecord::getAttribute()} dynamic return
+ * types provides accurate type inference for model properties and behavior-defined attributes.
+ *
+ * This validates the ability of the PHPStan extension to resolve property types from PHPDoc annotations in both model
+ * classes and their attached behaviors, with proper precedence handling when property names conflict.
+ *
+ * Key features.
+ * - Ensures compatibility with PHPStan extension configuration.
+ * - Loads and executes type assertions from a dedicated fixture file.
+ * - Uses PHPUnit DataProvider for parameterized test execution.
+ * - Validates type inference for {@see ActiveRecord::getAttribute()} method calls.
+ * - Verifies behavior property type resolution and model property precedence.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ActiveRecordGetAttributeDynamicMethodReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        $directory = dirname(__DIR__);
+
+        yield from self::gatherAssertTypes(
+            "{$directory}/data/type/ActiveRecordGetAttributeDynamicMethodReturnType.php",
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [dirname(__DIR__) . '/extension-test.neon'];
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced static analysis for dynamic attribute access in Yii ActiveRecord models, enabling precise type inference for getAttribute() calls based on PHPDoc annotations in both models and attached behaviors.
  - Improved documentation and examples illustrating dynamic attribute type inference and behavior PHPDoc requirements.

- **Tests**
  - Added comprehensive tests to verify correct type resolution for getAttribute(), including scenarios with multiple behaviors and property conflicts.

- **Documentation**
  - Expanded guides and examples to clarify type resolution precedence and demonstrate usage with behaviors and model properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->