### PR TITLE
ci: Remove `OS` and `PHP` version specifications from workflow files for simplification.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,6 @@ jobs:
       composer-command: |
         composer require yiisoft/yii2:22.0.x-dev --prefer-dist --no-progress --no-interaction --no-scripts --ansi
       concurrency-group: phpunit-${{ github.workflow }}-${{ github.ref }}
-      os: >-
-        ['ubuntu-latest', 'windows-latest']
-      php: >-
-        ['8.1', '8.2', '8.3', '8.4']
   phpunit-compatibility:
     uses: php-forge/actions/.github/workflows/phpunit.yml@main
     secrets:
@@ -37,7 +33,3 @@ jobs:
     with:
       concurrency-group: phpunit-compatibility-${{ github.workflow }}-${{ github.ref }}
       extensions: intl
-      os: >-
-        ['ubuntu-latest', 'windows-latest']
-      php: >-
-        ['8.1', '8.2', '8.3', '8.4']

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -23,7 +23,3 @@ jobs:
     with:
       composer-command: |
         composer require yiisoft/yii2:22.0.x-dev --prefer-dist --no-progress --no-interaction --no-scripts --ansi
-      os: >-
-        ['ubuntu-latest']
-      php: >-
-        ['8.4']

--- a/.github/workflows/ecs.yml
+++ b/.github/workflows/ecs.yml
@@ -25,7 +25,3 @@ jobs:
     with:
       composer-command: |
         composer require yiisoft/yii2:22.0.x-dev --prefer-dist --no-progress --no-interaction --no-scripts --ansi
-      os: >-
-        ['ubuntu-latest']
-      php: >-
-        ['8.4']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,10 +28,6 @@ jobs:
       composer-command: |
         composer require yiisoft/yii2:22.0.x-dev --prefer-dist --no-progress --no-interaction --no-scripts --ansi
       concurrency-group: phpstan-${{ github.workflow }}-${{ github.ref }}
-      os: >-
-        ['ubuntu-latest']
-      php: >-
-        ['8.4']
   phpstan-console:
     uses: php-forge/actions/.github/workflows/phpstan.yml@main
     with:
@@ -39,7 +35,3 @@ jobs:
       composer-command: |
         composer require yiisoft/yii2:22.0.x-dev --prefer-dist --no-progress --no-interaction --no-scripts --ansi
       concurrency-group: phpstan-console-${{ github.workflow }}-${{ github.ref }}
-      os: >-
-        ['ubuntu-latest']
-      php: >-
-        ['8.4']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bug #52: Standardize headings and improve clarity in documentation files (@terabytesoftw)
 - Bug #53: Update documentation for consistency and clarity; change section titles and add strict types declaration (@terabytesoftw)
 - Bug #54: Update `PHPStan` `tmpDir` config; move `runtime` directory to `root`; update docs (@terabytesoftw)
+- Bug #55: Remove `OS` and `PHP` version specifications from workflow files for simplification (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified GitHub Actions workflows by removing explicit operating system and PHP version specifications.
- **Documentation**
	- Updated the changelog to reflect the workflow configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->