### PR TITLE
feat: Add `ServiceLocatorDynamicMethodReturnTypeExtension` to provide precise type inference for `get()` method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Bug #53: Update documentation for consistency and clarity; change section titles and add strict types declaration (@terabytesoftw)
 - Bug #54: Update `PHPStan` `tmpDir` config; move `runtime` directory to `root`; update docs (@terabytesoftw)
 - Bug #55: Remove `OS` and `PHP` version specifications from workflow files for simplification (@terabytesoftw)
+- Enh #56: Add `ServiceLocatorDynamicMethodReturnTypeExtension` to provide precise type inference for `get()` method (@terabytesoftw)
 
 ## 0.2.3 June 09, 2025
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ inference, dynamic method resolution, and comprehensive property reflection.
 - Stub files for different application types (web, console, base).
 - Support for Yii2 constants (`YII_DEBUG`, `YII_ENV_*`).
 
+✅ **Service Locator Component Resolution**
+- Automatic fallback to mixed type for unknown component identifiers.
+- Dynamic return type inference for `ServiceLocator::get()` calls.
+- Priority-based resolution: ServiceMap components > ServiceMap services > Real classes > Mixed type.
+- Support for all Service Locator subclasses (Application, Module, custom classes).
+- Type inference with string variables and class name constants.
+
 ## Quick start
 
 ### Installation
@@ -159,7 +166,22 @@ $container = new Container();
 
 // ✅ Type-safe service resolution
 $service = $container->get(MyService::class); // MyService
-$logger = $container->get('logger');          // LoggerInterface (if configured)
+$logger = $container->get('logger');          // LoggerInterface (if configured) or mixed
+```
+
+#### Service locator
+
+```php
+$serviceLocator = new ServiceLocator();
+
+// ✅ Get component with type inference with class
+$mailer = $serviceLocator->get(Mailer::class);  // MailerInterface
+
+// ✅ Get component with string identifier and without configuration in ServiceMap
+$mailer = $serviceLocator->get('mailer');  // MailerInterface (if configured) or mixed
+
+// ✅ User component with proper type inference in Action or Controller
+$user = $this->controller->module->get('user'); // UserInterface
 ```
 
 ## Documentation

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -86,7 +86,7 @@ class PostRepository
     
     public function getLatestPost(): Post|null
     {
-        // ✅ PHPStan knows this returns Post|null
+        // ✅ PHPStan knows this return Post|null
         return Post::find()
             ->where(['status' => 'published'])
             ->orderBy('created_at DESC')
@@ -114,13 +114,13 @@ class UserModel extends \yii\db\ActiveRecord
 {
     public function getPosts(): \yii\db\ActiveQuery
     {
-        // ✅ PHPStan knows this returns ActiveQuery<Post>
+        // ✅ PHPStan knows this return ActiveQuery<Post>
         return $this->hasMany(Post::class, ['author_id' => 'id']);
     }
     
     public function getProfile(): \yii\db\ActiveQuery
     {
-        // ✅ PHPStan knows this returns ActiveQuery<UserProfile>
+        // ✅ PHPStan knows this return ActiveQuery<UserProfile>
         return $this->hasOne(UserProfile::class, ['user_id' => 'id']);
     }
 }
@@ -194,7 +194,7 @@ class Post extends \yii\db\ActiveRecord
 {
     public static function find(): PostQuery
     {
-        // ✅ PHPStan knows this returns PostQuery<Post>
+        // ✅ PHPStan knows this return PostQuery<Post>
         return new PostQuery(get_called_class());
     }
 }
@@ -429,7 +429,7 @@ class ServiceManager
     
     public function getPaymentService(): PaymentService
     {
-        // ✅ PHPStan knows this returns PaymentService
+        // ✅ PHPStan knows this return PaymentService
         return $this->container->get(PaymentService::class);
     }
     
@@ -450,6 +450,50 @@ class ServiceManager
         }
         
         return false;
+    }
+}
+```
+
+### Service locator in custom classes
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use yii\di\ServiceLocator;
+use app\services\{EmailService, LoggerService, CacheService};
+
+class CustomServiceManager extends ServiceLocator
+{
+    public function sendNotification(string $message): bool
+    {
+        // ✅ PHPStan knows these are the correct service types
+        $email = $this->get('emailService');   // EmailService
+        $logger = $this->get('loggerService'); // LoggerService
+        $cache = $this->get('cacheService');   // CacheService
+        
+        try {
+            $result = $email->send($message);
+            $logger->info('Notification sent successfully');
+            $cache->delete('pending_notifications');
+            
+            return $result;
+        } catch (\Exception $e) {
+            $logger->error('Failed to send notification: ' . $e->getMessage());
+            return false;
+        }
+    }
+    
+    public function getServicesByType(): array
+    {
+        // ✅ Different ways to resolve services
+        return [
+            'email_by_id' => $this->get('emailService'),           // EmailService
+            'email_by_class' => $this->get(EmailService::class),   // EmailService
+            'logger_by_id' => $this->get('loggerService'),         // LoggerService
+            'logger_by_class' => $this->get(LoggerService::class), // LoggerService
+        ];
     }
 }
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -48,6 +48,9 @@ services:
         class: yii2\extensions\phpstan\type\HeaderCollectionDynamicMethodReturnTypeExtension
         tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
     -
+        class: yii2\extensions\phpstan\type\ServiceLocatorDynamicMethodReturnTypeExtension
+        tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+    -
         class: yii2\extensions\phpstan\StubFilesExtension
         tags:
             - phpstan.stubFilesExtension

--- a/src/type/ServiceLocatorDynamicMethodReturnTypeExtension.php
+++ b/src/type/ServiceLocatorDynamicMethodReturnTypeExtension.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\type;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\{MethodReflection, ParametersAcceptorSelector, ReflectionProvider};
+use PHPStan\Type\{DynamicMethodReturnTypeExtension, MixedType, ObjectType, Type};
+use yii\di\ServiceLocator;
+use yii2\extensions\phpstan\ServiceMap;
+
+/**
+ * Provides dynamic return type extension for Yii Service Locator component resolution in PHPStan analysis.
+ *
+ * Integrates the Yii Service Locator service {@see ServiceLocator} with PHPStan dynamic method return type extension
+ * system, enabling precise type inference for {@see ServiceLocator::get()} calls based on component ID and the
+ * {@see ServiceMap}.
+ *
+ * This extension analyzes the first argument of {@see ServiceLocator::get()} to determine the most accurate return
+ * type, returning an {@see ObjectType} for known component classes or a {@see MixedType} for unknown or dynamic ID.
+ *
+ * Key features:
+ * - Accurate return type inference for {@see ServiceLocator::get()} based on component ID string.
+ * - Compatible with PHPStan strict static analysis and autocompletion.
+ * - Falls back to method signature return type for unsupported or invalid calls.
+ * - Supports Yii modules, applications, and any class extending {@see ServiceLocator}.
+ * - Uses {@see ServiceMap} to resolve component class names.
+ *
+ * @see DynamicMethodReturnTypeExtension for PHPStan dynamic return type extension contract.
+ * @see ServiceMap for service and component map for Yii Application static analysis.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ServiceLocatorDynamicMethodReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    /**
+     * Creates a new instance of the {@see ServiceLocatorDynamicMethodReturnTypeExtension} class.
+     *
+     * @param ReflectionProvider $reflectionProvider Reflection provider for class and property lookups.
+     * @param ServiceMap $serviceMap Service and component map for Yii Application static analysis.
+     */
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+        private readonly ServiceMap $serviceMap,
+    ) {}
+
+    /**
+     * Returns the class name for which this dynamic return type extension applies.
+     *
+     * Specifies the fully qualified class name of the Yii ServiceLocator {@see ServiceLocator} that this extension
+     * target for dynamic return type inference in PHPStan analysis.
+     *
+     * This method enables PHPStan to associate the extension with the {@see ServiceLocator} class and all its
+     * subclasses (like Module and Application), ensuring that dynamic return type logic is applied to component
+     * resolution calls.
+     *
+     * @return string Fully qualified class name of the supported ServiceLocator class.
+     *
+     * @phpstan-return class-string
+     */
+    public function getClass(): string
+    {
+        return ServiceLocator::class;
+    }
+
+    /**
+     * Infers the return type for a {@see ServiceLocator::get()} method call based on the provided component ID
+     * argument.
+     *
+     * Determines the most accurate return type for component resolution by analyzing the first argument of the
+     * {@see ServiceLocator::get()} call.
+     *
+     * - If the argument is a constant string and matches a known component in the {@see ServiceMap}, returns an
+     *   {@see ObjectType} for the resolved class.
+     * - If the argument is a class name known to the {@see ReflectionProvider}, returns an {@see ObjectType} for that
+     *   class.
+     * - Otherwise, returns a {@see MixedType} to indicate an unknown or dynamic component type.
+     *
+     * Falls back to the default method signature return type for unsupported or invalid calls, ensuring compatibility
+     * with PHPStan static analysis and IDE autocompletion.
+     *
+     * @param MethodReflection $methodReflection Reflection instance for the method being analyzed.
+     * @param MethodCall $methodCall AST node for the method call expression.
+     * @param Scope $scope PHPStan analysis scope for type resolution.
+     *
+     * @return Type Inferred return type for the component resolution call.
+     */
+    public function getTypeFromMethodCall(
+        MethodReflection $methodReflection,
+        MethodCall $methodCall,
+        Scope $scope,
+    ): Type {
+        if (isset($methodCall->args[0]) === false || $methodCall->args[0]::class !== Arg::class) {
+            return ParametersAcceptorSelector::selectFromArgs(
+                $scope,
+                $methodCall->getArgs(),
+                $methodReflection->getVariants(),
+            )->getReturnType();
+        }
+
+        $argType = $scope->getType($methodCall->args[0]->value);
+        $constantStrings = $argType->getConstantStrings();
+
+        if (count($constantStrings) === 1) {
+            $value = $constantStrings[0]->getValue();
+
+            $componentClass = $this->serviceMap->getComponentClassById($value);
+
+            if ($componentClass !== null) {
+                return new ObjectType($componentClass);
+            }
+
+            $serviceClass = $this->serviceMap->getServiceById($value);
+
+            if ($serviceClass !== null) {
+                return new ObjectType($serviceClass);
+            }
+
+            if ($this->reflectionProvider->hasClass($value)) {
+                return new ObjectType($value);
+            }
+        }
+
+        return new MixedType();
+    }
+
+    /**
+     * Determines whether the specified method is supported for dynamic return type inference.
+     *
+     * Checks if the method name is {@see ServiceLocator::get}, which is the only method supported by this extension for
+     * dynamic return type analysis.
+     *
+     * This enables PHPStan to apply custom type inference logic exclusively to component resolution calls on the Yii
+     * Service Locator {@see ServiceLocator} and its subclasses (Module, Application).
+     *
+     * @param MethodReflection $methodReflection Reflection instance for the method being analyzed.
+     *
+     * @return bool `true` if the method is {@see ServiceLocator::get}; `false` otherwise.
+     */
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get';
+    }
+}

--- a/tests/data/type/ServiceLocatorDynamicMethodReturnType.php
+++ b/tests/data/type/ServiceLocatorDynamicMethodReturnType.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\data\type;
+
+use yii\base\InvalidConfigException;
+use yii\base\Module;
+use yii\di\ServiceLocator;
+use yii\web\{Application, Request, Response, Session, User};
+use yii2\extensions\phpstan\tests\stub\MyActiveRecord;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Test suite for dynamic return types of {@see ServiceLocator::get()} in Yii component scenarios.
+ *
+ * Validates type inference and return types for the service locator {@see ServiceLocator::get()} method, covering
+ * scenarios with component IDs, class names, module components, application components, and various service resolution
+ * patterns.
+ *
+ * These tests ensure that PHPStan correctly infers the result types for ServiceLocator lookups, including
+ * component-based resolution, service aliases, known Yii components, and unknown component identifiers.
+ *
+ * Key features:
+ * - Component resolution from ServiceMap configuration.
+ * - Mixed type handling for unknown or dynamic component IDs.
+ * - Module and Application component access patterns.
+ * - Priority testing: ServiceMap components > ServiceMap services > Real classes > Unknown.
+ * - Type assertions for various Yii2 built-in components.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ServiceLocatorDynamicMethodReturnType
+{
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnClassWhenGetByClassName(): void
+    {
+        $locator = new ServiceLocator();
+
+        assertType('yii2\extensions\phpstan\tests\stub\MyActiveRecord', $locator->get(MyActiveRecord::class));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnClassWhenGetByClassNameString(): void
+    {
+        $locator = new ServiceLocator();
+
+        $className = 'yii2\extensions\phpstan\tests\stub\MyActiveRecord';
+
+        assertType(MyActiveRecord::class, $locator->get($className));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnMixedWhenGetWithUnknownId(): void
+    {
+        $locator = new ServiceLocator();
+
+        assertType('mixed', $locator->get('unknown-component'));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnServicesWhenGetByBuiltInClassNames(): void
+    {
+        $locator = new ServiceLocator();
+
+        assertType(User::class, $locator->get(User::class));
+        assertType(Request::class, $locator->get(Request::class));
+        assertType(Response::class, $locator->get(Response::class));
+        assertType(Session::class, $locator->get(Session::class));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnServiceWhenGetByComponentId(): void
+    {
+        $locator = new ServiceLocator();
+
+        assertType(User::class, $locator->get('user'));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnServiceWhenGetByComponentIdWithForceCreate(): void
+    {
+        $locator = new ServiceLocator();
+
+        assertType(User::class, $locator->get('user'));
+        assertType(User::class, $locator->get('user', false));
+        assertType(User::class, $locator->get(User::class));
+        assertType(User::class, $locator->get(User::class, false));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnServiceWhenGetFromApplicationByIdOrClassName(): void
+    {
+        $application = new Application();
+
+        assertType(User::class, $application->get('user'));
+        assertType(User::class, $application->get(User::class));
+    }
+
+    /**
+     * @throws InvalidConfigException if the configuration is invalid or incomplete.
+     */
+    public function testReturnServiceWhenGetFromModuleByIdOrClassName(): void
+    {
+        $module = new Module('test');
+
+        assertType(User::class, $module->get('user'));
+        assertType(User::class, $module->get(User::class));
+    }
+}

--- a/tests/type/ServiceLocatorDynamicMethodReturnTypeExtensionTest.php
+++ b/tests/type/ServiceLocatorDynamicMethodReturnTypeExtensionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\type;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use yii\di\ServiceLocator;
+
+/**
+ * Test suite for type inference of dynamic method return types in {@see ServiceLocator} for Yii component scenarios.
+ *
+ * Validates that PHPStan correctly infers types for dynamic ServiceLocator method calls and result sets in custom
+ * {@see ServiceLocator} usage, using fixture-based assertions for component resolution, dependency injection, and
+ * property access.
+ *
+ * The test class loads type assertions from a fixture file and delegates checks to the parent
+ * {@see TypeInferenceTestCase}, ensuring that extension logic for {@see ServiceLocator} dynamic method return types is
+ * robust and consistent with expected behavior.
+ *
+ * Key features:
+ * - Ensures compatibility with PHPStan extension configuration.
+ * - Loads and executes type assertions from a dedicated fixture file.
+ * - Uses PHPUnit DataProvider for parameterized test execution.
+ * - Validates type inference for chained query methods and result types.
+ *
+ * @copyright Copyright (C) 2023 Terabytesoftw.
+ * @license https://opensource.org/license/bsd-3-clause BSD 3-Clause License.
+ */
+final class ServiceLocatorDynamicMethodReturnTypeExtensionTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        $directory = dirname(__DIR__);
+
+        yield from self::gatherAssertTypes(
+            "{$directory}/data/type/ServiceLocatorDynamicMethodReturnType.php",
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [dirname(__DIR__) . '/extension-test.neon'];
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced type inference for the `ServiceLocator::get()` method, providing more precise static analysis and autocompletion support in Yii2 applications.

- **Documentation**
  - Updated README and documentation examples to describe and demonstrate the improved type inference for service locator usage, including new code samples and clarifications.

- **Tests**
  - Added comprehensive tests to verify dynamic return type inference for service locator methods, ensuring reliability and correctness of the new feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->