### PR TITLE
fix: Add `case` to the ordered class elements in ECS configuration.

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -26,6 +26,7 @@ return ECSConfig::configure()
                 'constant_public',
                 'constant_protected',
                 'constant_private',
+                'case',
                 'property_public',
                 'property_protected',
                 'property_private',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
