### PR TITLE
fix: Add missing `Composer` requirement in installation guide.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,6 +3,7 @@
 ## System requirements
 
 - [`PHP`](https://www.php.net/downloads) 8.1 or higher.
+- [`Composer`](https://getcomposer.org/download/) for dependency management.
 - [`PHPStan`](https://github.com/phpstan/phpstan) 2.1 or higher.
 - [`Yii2`](https://github.com/yiisoft/yii2) 2.0.53+ or 22.x.
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to include Composer as a required prerequisite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->