### PR TITLE
fix: Correct default stub file name in `StubFilesExtension.php` for accurate PHPStan analysis.

### DIFF
--- a/src/StubFilesExtension.php
+++ b/src/StubFilesExtension.php
@@ -39,7 +39,7 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
         \yii\web\Application::class => 'BaseYiiWeb.stub',
     ];
 
-    private const DEFAULT_STUB = 'ApplicationWeb.stub';
+    private const DEFAULT_STUB = 'BaseYiiWeb.stub';
 
     /**
      * @param ServiceMap $serviceMap Service and component map for Yii Application static analysis.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default fallback stub file name used when the application type is not recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->