### PR TITLE
fix: Update `.gitattributes` to exclude additional files from the package.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,7 @@
 /CHANGELOG.md		merge=union
 
 # Exclude files from the archive
+/.editorconfig                  export-ignore
 /.gitattributes                 export-ignore
 /.github                        export-ignore
 /.gitignore                     export-ignore
@@ -33,7 +34,11 @@
 /codeception.yml                export-ignore
 /composer-require-checker.json  export-ignore
 /docs                           export-ignore
+/ecs.php                        export-ignore
+/infection.json5                export-ignore
+/phpstan.neon                   export-ignore
 /phpunit.xml.dist               export-ignore
 /psalm.xml                      export-ignore
 /rector.php                     export-ignore
+/runtime                        export-ignore
 /tests                          export-ignore


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
