### PR TITLE
fix: Exclude `phpstan-console.neon` from the package in `.gitattributes`.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,7 @@
 /docs                           export-ignore
 /ecs.php                        export-ignore
 /infection.json5                export-ignore
+/phpstan-console.neon           export-ignore
 /phpstan.neon                   export-ignore
 /phpunit.xml.dist               export-ignore
 /psalm.xml                      export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.2 Under development
 
 - Bug #71: Update `.gitattributes` to exclude additional files from the package (@terabytesoftw)
+- Bug #72: Exclude `phpstan-console.neon` from the package in `.gitattributes` (@terabytesoftw)
 
 ## 0.3.1 August 16, 2025
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Improved packaging by excluding a development-only analysis configuration from release archives, reducing package size and noise. No runtime, behavior, or API changes.

- Documentation
  - Updated changelog to note the packaging exclusion in the upcoming release.

- Bug Fixes
  - None.

- Tests
  - None.

- Refactor
  - None.

- Style
  - None.

- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->