### PR TITLE
feat: add `Yii::$app->params` type inference from configuration for precise array shape typing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: update Rector command in `composer.json` to remove unnecessary 'src' argument.
 - feat: replace static stub files with dynamic stub generation for `Yii::$app` type inference, adding support for custom application types.
 - chore: remove `sync-metadata` script and `docs/development.md`, update documentation links.
+- feat: add `Yii::$app->params` type inference from configuration for precise array shape typing.
 
 ## 0.4.0 January 26, 2026
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ if (Yii::$app->user->isGuest === false) {
 ```php
 // Types are inferred from the values in your phpstan-config.php 'params' key
 
-// ✅ Typed as array{turnstile.siteKey: string, adminEmail: string, maxItems: int}
+// ✅ Typed as array{'turnstile.siteKey': string, adminEmail: string, maxItems: int}
 $params = Yii::$app->params;
 
 // ✅ Typed as string

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Create a PHPStan-specific config file (`config/phpstan-config.php`).
 declare(strict_types=1);
 
 return [
+    // Application params: enables precise type inference for Yii::$app->params
+    'params' => [
+        'turnstile.siteKey' => '',
+        'adminEmail' => 'admin@example.com',
+        'maxItems' => 100,
+    ],
     // PHPStan only: used by this extension for behavior property/method type inference
     'behaviors' => [
         app\models\User::class => [
@@ -134,6 +140,25 @@ if (Yii::$app->user->isGuest === false) {
     $userId = Yii::$app->user->id;           // int|string|null
     $identity = Yii::$app->user->identity;   // YourUserClass
 }
+```
+
+#### Application params
+
+```php
+// Types are inferred from the values in your phpstan-config.php 'params' key
+
+// ✅ Typed as array{turnstile.siteKey: string, adminEmail: string, maxItems: int}
+$params = Yii::$app->params;
+
+// ✅ Typed as string
+$email = Yii::$app->params['adminEmail'];
+
+// ✅ Typed as int
+$maxItems = Yii::$app->params['maxItems'];
+
+// ✅ Nested arrays are also supported
+// 'nested' => ['db' => ['host' => 'localhost', 'port' => 3306]]
+$host = Yii::$app->params['nested']['db']['host']; // string
 ```
 
 #### Behaviors

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "ecs": "./vendor/bin/ecs --fix",
         "rector": "./vendor/bin/rector process",
         "static": "./vendor/bin/phpstan --memory-limit=-1",
-        "tests": "./vendor/bin/phpunit"
+        "tests": "php -d memory_limit=-1 ./vendor/bin/phpunit"
     },
     "repositories": [
         {

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -54,7 +54,8 @@ use function sprintf;
  *   container?: array{
  *     definitions?: array<array-key, DefinitionType>,
  *     singletons?: array<array-key, DefinitionType>,
- *   }
+ *   },
+ *   params?: array<string, mixed>,
  * }
  *
  * @copyright Copyright (C) 2023 Terabytesoftw.
@@ -98,6 +99,13 @@ final class ServiceMap
     private array $componentsDefinitions = [];
 
     /**
+     * Application params for PHPStan type inference.
+     *
+     * @phpstan-var array<string, mixed>
+     */
+    private array $params = [];
+
+    /**
      * Service definitions map for Yii Application analysis.
      *
      * @phpstan-var class-string[]|string[]
@@ -133,6 +141,7 @@ final class ServiceMap
         $this->processBehaviors($config);
         $this->processComponents($config);
         $this->processDefinition($config);
+        $this->processParams($config);
         $this->processSingletons($config);
     }
 
@@ -238,6 +247,19 @@ final class ServiceMap
     }
 
     /**
+     * Retrieves the application params map for PHPStan type inference.
+     *
+     * Returns the `params` key-value pairs extracted from the Yii Application configuration file, enabling static
+     * analysis tools to infer precise array shape types for `Yii::$app->params` access.
+     *
+     * @return array<string, mixed> Params key-value pairs from configuration.
+     */
+    public function getParams(): array
+    {
+        return $this->params;
+    }
+
+    /**
      * Retrieves the fully qualified class name of a Yii Service by its identifier.
      *
      * Looks up the service class name registered under the specified service ID in the internal service map.
@@ -304,6 +326,10 @@ final class ServiceMap
 
         if (isset($config['components']) && is_array($config['components']) === false) {
             $this->throwErrorWhenConfigFileIsNotArray($configPath, 'components');
+        }
+
+        if (isset($config['params']) && is_array($config['params']) === false) {
+            $this->throwErrorWhenConfigFileIsNotArray($configPath, 'params');
         }
 
         if (isset($config['container'])) {
@@ -518,6 +544,23 @@ final class ServiceMap
     }
 
     /**
+     * Processes application params from the Yii Application configuration array.
+     *
+     * Extracts the `params` section and stores it for type inference of `Yii::$app->params` array access.
+     *
+     * @param array $config Yii Application configuration array containing params definitions.
+     *
+     * @phpstan-import-type ServiceType from ServiceMap
+     * @phpstan-param ServiceType $config
+     */
+    private function processParams(array $config): void
+    {
+        if ($config !== []) {
+            $this->params = $config['params'] ?? [];
+        }
+    }
+
+    /**
      * Processes singleton service definitions from the Yii Application configuration array.
      *
      * Iterates over the container.singletons section of the provided configuration array, normalizing and registering
@@ -584,7 +627,9 @@ final class ServiceMap
      */
     private function throwErrorWhenIsNotString(string ...$args): never
     {
-        throw new RuntimeException(sprintf("'%s': '%s' must be a 'string', got '%s'.", ...$args));
+        throw new RuntimeException(
+            sprintf("'%s': '%s' must be a 'string', got '%s'.", ...$args),
+        );
     }
 
     /**
@@ -602,6 +647,8 @@ final class ServiceMap
      */
     private function throwErrorWhenUnsupportedDefinition(string $id): never
     {
-        throw new RuntimeException(sprintf("Unsupported definition for '%s'.", $id));
+        throw new RuntimeException(
+            sprintf("Unsupported definition for '%s'.", $id),
+        );
     }
 }

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -12,6 +12,7 @@ use RuntimeException;
 use yii\base\{BaseObject, InvalidArgumentException};
 use yii\web\Application;
 
+use function array_key_exists;
 use function define;
 use function defined;
 use function file_exists;
@@ -328,7 +329,7 @@ final class ServiceMap
             $this->throwErrorWhenConfigFileIsNotArray($configPath, 'components');
         }
 
-        if (isset($config['params']) && is_array($config['params']) === false) {
+        if (array_key_exists('params', $config) && is_array($config['params']) === false) {
             $this->throwErrorWhenConfigFileIsNotArray($configPath, 'params');
         }
 

--- a/src/StubFilesExtension.php
+++ b/src/StubFilesExtension.php
@@ -242,10 +242,10 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
         }
 
         /**
-         * @codeCoverageIgnoreStart
-         * atomic publish: rename within the same filesystem is atomic on POSIX. This fallback handles Windows (where
+         * Atomic publish: rename within the same filesystem is atomic on POSIX. This fallback handles Windows (where
          * rename fails if target exists) and other non-POSIX edge cases during concurrent PHPStan runs.
          */
+        //@codeCoverageIgnoreStart
         if (!@rename($temporaryPath, $stubPath)) {
             @unlink($temporaryPath);
 
@@ -257,7 +257,7 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
                 sprintf("Failed to write stub file to '%s'. Ensure the temporary directory is writable.", $stubPath),
             );
         }
-        /** @codeCoverageIgnoreEnd */
+        //@codeCoverageIgnoreEnd
 
         return $stubPath;
     }

--- a/src/StubFilesExtension.php
+++ b/src/StubFilesExtension.php
@@ -7,11 +7,19 @@ namespace yii2\extensions\phpstan;
 use RuntimeException;
 use yii\base\Application;
 
+use function array_keys;
 use function file_exists;
 use function file_put_contents;
 use function getmypid;
+use function implode;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
 use function ltrim;
 use function md5;
+use function preg_match;
 use function rename;
 use function sprintf;
 use function strrpos;
@@ -76,8 +84,14 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
      */
     private function buildApplicationTypeDeclaration(string $applicationType): string
     {
+        $paramsProperty = $this->buildParamsPropertyDeclaration();
+
         $baseDeclaration = <<<PHP
         namespace yii\base {
+            class Module
+            {{$paramsProperty}
+            }
+
             abstract class Application {}
         }
         PHP;
@@ -105,6 +119,33 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
                 class {$className} extends \yii\base\Application {}
             }
             PHP;
+    }
+
+    /**
+     * Builds the `$params` property declaration for the stub file.
+     *
+     * Generates a PHPDoc `@var` annotation with an array shape type inferred from the configured application params.
+     * Returns an empty string if no params are configured, allowing the native `array` type to remain unchanged.
+     *
+     * @return string PHP property declaration block with array shape annotation, or empty string if no params.
+     */
+    private function buildParamsPropertyDeclaration(): string
+    {
+        $params = $this->serviceMap->getParams();
+
+        if ($params === []) {
+            return '';
+        }
+
+        $typeString = $this->inferTypeString($params);
+
+        return <<<PHP
+
+                /**
+                 * @var {$typeString}
+                 */
+                public \$params;
+        PHP;
     }
 
     /**
@@ -178,9 +219,11 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
             );
         }
 
-        // @codeCoverageIgnoreStart
-        // atomic publish: rename within the same filesystem is atomic on POSIX. This fallback handles Windows (where
-        // rename fails if target exists) and other non-POSIX edge cases during concurrent PHPStan runs.
+        /**
+         * @codeCoverageIgnoreStart
+         * atomic publish: rename within the same filesystem is atomic on POSIX. This fallback handles Windows (where
+         * rename fails if target exists) and other non-POSIX edge cases during concurrent PHPStan runs.
+         */
         if (!@rename($temporaryPath, $stubPath)) {
             @unlink($temporaryPath);
 
@@ -192,8 +235,81 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
                 sprintf("Failed to write stub file to '%s'. Ensure the temporary directory is writable.", $stubPath),
             );
         }
-        // @codeCoverageIgnoreEnd
+        /** @codeCoverageIgnoreEnd */
 
         return $stubPath;
+    }
+
+    /**
+     * Infers a PHPStan type string from a PHP value.
+     *
+     * Converts PHP scalar values and arrays to their corresponding PHPStan type annotation strings. Supports `string`,
+     * `int`, `float`, `bool`, `null`, associative arrays (array shapes), and list arrays.
+     *
+     * @param mixed $value PHP value to infer a type string from.
+     *
+     * @return string PHPStan type annotation string.
+     */
+    private function inferTypeString(mixed $value): string
+    {
+        if ($value === null) {
+            return 'null';
+        }
+
+        if (is_string($value)) {
+            return 'string';
+        }
+
+        if (is_int($value)) {
+            return 'int';
+        }
+
+        if (is_float($value)) {
+            return 'float';
+        }
+
+        if (is_bool($value)) {
+            return 'bool';
+        }
+
+        if (is_array($value)) {
+            if ($value === []) {
+                return 'array<mixed, mixed>';
+            }
+
+            $allStringKeys = true;
+
+            foreach (array_keys($value) as $k) {
+                if (is_string($k) === false) {
+                    $allStringKeys = false;
+
+                    break;
+                }
+            }
+
+            if ($allStringKeys) {
+                $entries = [];
+
+                foreach ($value as $k => $v) {
+                    /** @phpstan-var string $k */
+                    $formattedKey = preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $k) === 1
+                        ? $k
+                        : "'$k'";
+                    $entries[] = $formattedKey . ': ' . $this->inferTypeString($v);
+                }
+
+                return 'array{' . implode(', ', $entries) . '}';
+            }
+
+            $entries = [];
+
+            foreach ($value as $v) {
+                $entries[] = $this->inferTypeString($v);
+            }
+
+            return 'array{' . implode(', ', $entries) . '}';
+        }
+
+        return 'mixed';
     }
 }

--- a/src/StubFilesExtension.php
+++ b/src/StubFilesExtension.php
@@ -7,6 +7,7 @@ namespace yii2\extensions\phpstan;
 use RuntimeException;
 use yii\base\Application;
 
+use function array_is_list;
 use function array_keys;
 use function file_exists;
 use function file_put_contents;
@@ -22,6 +23,7 @@ use function md5;
 use function preg_match;
 use function rename;
 use function sprintf;
+use function str_replace;
 use function strrpos;
 use function substr;
 use function sys_get_temp_dir;
@@ -184,6 +186,26 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
     }
 
     /**
+     * Formats an array key for use in a PHPStan array shape type annotation.
+     *
+     * Wraps keys containing non-identifier characters in single quotes to satisfy PHPStan type syntax.
+     *
+     * @param string $key Array key to format.
+     *
+     * @return string Formatted key, quoted if it contains special characters.
+     */
+    private function formatArrayKey(string $key): string
+    {
+        if (preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $key) === 1) {
+            return $key;
+        }
+
+        $escaped = str_replace(['\\', "'"], ['\\\\', "\\'"], $key);
+
+        return "'{$escaped}'";
+    }
+
+    /**
      * Generates a stub file for the specified application type.
      *
      * Creates a PHP stub that overrides the `BaseYii::$app` property type annotation to match the configured
@@ -241,16 +263,73 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
     }
 
     /**
-     * Infers a PHPStan type string from a PHP value.
+     * Infers a PHPStan array type string from a PHP array value.
      *
-     * Converts PHP scalar values and arrays to their corresponding PHPStan type annotation strings. Supports `string`,
-     * `int`, `float`, `bool`, `null`, associative arrays (array shapes), and list arrays.
+     * Builds an array shape type for associative arrays (recursive) and list arrays. Returns `array<mixed, mixed>` for
+     * empty arrays.
      *
-     * @param mixed $value PHP value to infer a type string from.
+     * @param array<array-key, mixed> $value PHP array to infer a type string from.
      *
-     * @return string PHPStan type annotation string.
+     * @return string PHPStan array type annotation string.
      */
-    private function inferTypeString(mixed $value): string
+    private function inferArrayType(array $value): string
+    {
+        if ($value === []) {
+            return 'array<mixed, mixed>';
+        }
+
+        $allStringKeys = true;
+
+        foreach (array_keys($value) as $k) {
+            if (is_string($k) === false) {
+                $allStringKeys = false;
+
+                break;
+            }
+        }
+
+        if ($allStringKeys) {
+            $entries = [];
+
+            foreach ($value as $k => $v) {
+                /** @phpstan-var string $k */
+                $entries[] = $this->formatArrayKey($k) . ': ' . $this->inferTypeString($v);
+            }
+
+            return 'array{' . implode(', ', $entries) . '}';
+        }
+
+        if (array_is_list($value)) {
+            $entries = [];
+
+            foreach ($value as $v) {
+                $entries[] = $this->inferTypeString($v);
+            }
+
+            return 'array{' . implode(', ', $entries) . '}';
+        }
+
+        $entries = [];
+
+        foreach ($value as $k => $v) {
+            $key = is_int($k) ? (string) $k : $this->formatArrayKey($k);
+            $entries[] = $key . ': ' . $this->inferTypeString($v);
+        }
+
+        return 'array{' . implode(', ', $entries) . '}';
+    }
+
+    /**
+     * Infers a PHPStan scalar type string from a PHP value.
+     *
+     * Returns the type name for `null`, `string`, `int`, `float`, and `bool` values, or `null` if the value is not a
+     * scalar type.
+     *
+     * @param mixed $value PHP value to check.
+     *
+     * @return string|null PHPStan type name, or `null` if not a recognized scalar.
+     */
+    private function inferScalarType(mixed $value): string|null
     {
         if ($value === null) {
             return 'null';
@@ -272,42 +351,29 @@ final class StubFilesExtension implements \PHPStan\PhpDoc\StubFilesExtension
             return 'bool';
         }
 
+        return null;
+    }
+
+    /**
+     * Infers a PHPStan type string from a PHP value.
+     *
+     * Delegates to {@see inferScalarType()} for scalar values and {@see inferArrayType()} for arrays. Falls back to
+     * `mixed` for unsupported value types.
+     *
+     * @param mixed $value PHP value to infer a type string from.
+     *
+     * @return string PHPStan type annotation string.
+     */
+    private function inferTypeString(mixed $value): string
+    {
+        $scalarType = $this->inferScalarType($value);
+
+        if ($scalarType !== null) {
+            return $scalarType;
+        }
+
         if (is_array($value)) {
-            if ($value === []) {
-                return 'array<mixed, mixed>';
-            }
-
-            $allStringKeys = true;
-
-            foreach (array_keys($value) as $k) {
-                if (is_string($k) === false) {
-                    $allStringKeys = false;
-
-                    break;
-                }
-            }
-
-            if ($allStringKeys) {
-                $entries = [];
-
-                foreach ($value as $k => $v) {
-                    /** @phpstan-var string $k */
-                    $formattedKey = preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $k) === 1
-                        ? $k
-                        : "'$k'";
-                    $entries[] = $formattedKey . ': ' . $this->inferTypeString($v);
-                }
-
-                return 'array{' . implode(', ', $entries) . '}';
-            }
-
-            $entries = [];
-
-            foreach ($value as $v) {
-                $entries[] = $this->inferTypeString($v);
-            }
-
-            return 'array{' . implode(', ', $entries) . '}';
+            return $this->inferArrayType($value);
         }
 
         return 'mixed';

--- a/tests/ServiceMapParamsTest.php
+++ b/tests/ServiceMapParamsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionException;
+use RuntimeException;
+use yii2\extensions\phpstan\ServiceMap;
+
+/**
+ * Test suite for {@see ServiceMap} params resolution and validation logic.
+ *
+ * Validates correct extraction and retrieval of application params from configuration files, ensuring robust error
+ * handling for invalid params structures.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.4.1
+ */
+final class ServiceMapParamsTest extends TestCase
+{
+    /**
+     * Base path for configuration files used in tests.
+     */
+    private const BASE_PATH = __DIR__ . DIRECTORY_SEPARATOR . 'config' . DIRECTORY_SEPARATOR;
+
+    /**
+     * @throws ReflectionException if the component definition is invalid or can't be resolved.
+     */
+    public function testReturnEmptyParamsWhenConfigHasNoParams(): void
+    {
+        $serviceMap = new ServiceMap(self::BASE_PATH . 'phpstan-console-config.php');
+
+        self::assertSame(
+            [],
+            $serviceMap->getParams(),
+            'ServiceMap should return an empty array when no params are configured.',
+        );
+    }
+
+    /**
+     * @throws ReflectionException if the component definition is invalid or can't be resolved.
+     */
+    public function testReturnParamsFromConfig(): void
+    {
+        $serviceMap = new ServiceMap(self::BASE_PATH . 'params-config.php');
+
+        $params = $serviceMap->getParams();
+
+        self::assertSame(
+            [
+                'turnstile.siteKey' => '',
+                'adminEmail' => 'admin@example.com',
+                'maxItems' => 100,
+                'debugMode' => true,
+                'ratio' => 1.5,
+                'nullableParam' => null,
+                'nested' => ['key1' => 'value1', 'key2' => 42],
+                'tags' => ['php', 'yii2'],
+            ],
+            $params,
+            'ServiceMap should return all params from configuration.',
+        );
+    }
+
+    /**
+     * @throws ReflectionException if the component definition is invalid or can't be resolved.
+     */
+    public function testThrowExceptionWhenParamsNotArray(): void
+    {
+        $configPath = self::BASE_PATH . 'params-unsupported-is-not-array.php';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            "Configuration file '{$configPath}' must contain a valid 'params' 'array'.",
+        );
+
+        new ServiceMap($configPath);
+    }
+}

--- a/tests/ServiceMapParamsTest.php
+++ b/tests/ServiceMapParamsTest.php
@@ -67,6 +67,21 @@ final class ServiceMapParamsTest extends TestCase
     /**
      * @throws ReflectionException if the component definition is invalid or can't be resolved.
      */
+    public function testThrowExceptionWhenParamsIsNull(): void
+    {
+        $configPath = self::BASE_PATH . 'params-unsupported-is-null.php';
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            "Configuration file '{$configPath}' must contain a valid 'params' 'array'.",
+        );
+
+        new ServiceMap($configPath);
+    }
+
+    /**
+     * @throws ReflectionException if the component definition is invalid or can't be resolved.
+     */
     public function testThrowExceptionWhenParamsNotArray(): void
     {
         $configPath = self::BASE_PATH . 'params-unsupported-is-not-array.php';

--- a/tests/StubFilesExtensionTest.php
+++ b/tests/StubFilesExtensionTest.php
@@ -294,9 +294,9 @@ final class StubFilesExtensionTest extends TestCase
         $stubContent = (string) file_get_contents($stubPath);
 
         self::assertStringContainsString(
-            "array{emptyList: array<mixed, mixed>, siteName: string, sparse: array{2: string, 5: string}, 'O\\'Reilly': string, 'C:\\\\path': string}",
+            "array{emptyList: array<mixed, mixed>, siteName: string, sparse: array{2: string, 5: string}, 'O\\'Reilly': string, 'C:\\\\path': string, resource: mixed}",
             $stubContent,
-            "Stub should infer empty array as 'array<mixed, mixed>', sparse array with explicit keys, and escape special characters in quoted keys.",
+            "Stub should infer empty array as 'array<mixed, mixed>', sparse array with explicit keys, escape special characters in quoted keys, and fallback to 'mixed' for unsupported types.",
         );
 
         $this->generatedStubs[] = $stubPath;

--- a/tests/StubFilesExtensionTest.php
+++ b/tests/StubFilesExtensionTest.php
@@ -273,6 +273,35 @@ final class StubFilesExtensionTest extends TestCase
         $this->generatedStubs[] = $stubPath;
     }
 
+    public function testGetFilesReturnsStubWithEmptyArrayParamType(): void
+    {
+        $this->cleanGeneratedStubs();
+
+        $ds = DIRECTORY_SEPARATOR;
+        $configPath = __DIR__ . "{$ds}config{$ds}params-empty-array-config.php";
+
+        $stubFilesExtension = new StubFilesExtension(new ServiceMap($configPath));
+
+        $files = $stubFilesExtension->getFiles();
+
+        $stubPath = $files[0] ?? null;
+
+        self::assertNotNull(
+            $stubPath,
+            "Stub file path should not be 'null'.",
+        );
+
+        $stubContent = (string) file_get_contents($stubPath);
+
+        self::assertStringContainsString(
+            "array{emptyList: array<mixed, mixed>, siteName: string, sparse: array{2: string, 5: string}, 'O\\'Reilly': string, 'C:\\\\path': string}",
+            $stubContent,
+            "Stub should infer empty array as 'array<mixed, mixed>', sparse array with explicit keys, and escape special characters in quoted keys.",
+        );
+
+        $this->generatedStubs[] = $stubPath;
+    }
+
     public function testThrowExceptionWhenStubFileCannotBeWritten(): void
     {
         $ds = DIRECTORY_SEPARATOR;
@@ -281,7 +310,9 @@ final class StubFilesExtensionTest extends TestCase
         $stubFilesExtension = new StubFilesExtension(new ServiceMap(), $nonWritableDir);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Ensure the temporary directory is writable.');
+        $this->expectExceptionMessage(
+            'Ensure the temporary directory is writable.',
+        );
 
         $stubFilesExtension->getFiles();
     }

--- a/tests/config/params-config.php
+++ b/tests/config/params-config.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'params' => [
+        'turnstile.siteKey' => '',
+        'adminEmail' => 'admin@example.com',
+        'maxItems' => 100,
+        'debugMode' => true,
+        'ratio' => 1.5,
+        'nullableParam' => null,
+        'nested' => [
+            'key1' => 'value1',
+            'key2' => 42,
+        ],
+        'tags' => [
+            'php',
+            'yii2',
+        ],
+    ],
+];

--- a/tests/config/params-empty-array-config.php
+++ b/tests/config/params-empty-array-config.php
@@ -9,5 +9,6 @@ return [
         'sparse' => [2 => 'a', 5 => 'b'],
         "O'Reilly" => 'publisher',
         'C:\\path' => 'windows',
+        'resource' => fopen('php://memory', 'r'),
     ],
 ];

--- a/tests/config/params-empty-array-config.php
+++ b/tests/config/params-empty-array-config.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'params' => [
+        'emptyList' => [],
+        'siteName' => 'My App',
+        'sparse' => [2 => 'a', 5 => 'b'],
+        "O'Reilly" => 'publisher',
+        'C:\\path' => 'windows',
+    ],
+];

--- a/tests/config/params-unsupported-is-not-array.php
+++ b/tests/config/params-unsupported-is-not-array.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'params' => 'invalid',
+];

--- a/tests/config/params-unsupported-is-null.php
+++ b/tests/config/params-unsupported-is-null.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'params' => null,
+];

--- a/tests/config/phpstan-config.php
+++ b/tests/config/phpstan-config.php
@@ -17,6 +17,19 @@ use yii2\extensions\phpstan\tests\support\stub\{
 };
 
 return [
+    'params' => [
+        'turnstile.siteKey' => '',
+        'adminEmail' => 'admin@example.com',
+        'maxItems' => 100,
+        'debugMode' => true,
+        'ratio' => 1.5,
+        'nullableParam' => null,
+        'nested' => [
+            'key1' => 'value1',
+            'key2' => 42,
+        ],
+        'tags' => ['php', 'yii2'],
+    ],
     'behaviors' => [
         ModelWithConflictingProperty::class => [
             NestedSetsBehavior::class,

--- a/tests/config/phpstan-params-config.php
+++ b/tests/config/phpstan-params-config.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use yii2\extensions\phpstan\tests\support\stub\{MyActiveRecord, User};
+
+return [
+    'components' => [
+        'customComponent' => [
+            'class' => MyActiveRecord::class,
+        ],
+        'user' => [
+            'class' => 'yii\web\User',
+            'identityClass' => User::class,
+        ],
+    ],
+    'params' => [
+        'turnstile.siteKey' => '',
+        'adminEmail' => 'admin@example.com',
+        'maxItems' => 100,
+        'debugMode' => true,
+        'ratio' => 1.5,
+        'nullableParam' => null,
+        'nested' => [
+            'key1' => 'value1',
+            'key2' => 42,
+        ],
+        'tags' => [
+            'php',
+            'yii2',
+        ],
+    ],
+];

--- a/tests/support/extension-params-test.neon
+++ b/tests/support/extension-params-test.neon
@@ -1,0 +1,6 @@
+includes:
+    - ../../extension.neon
+
+parameters:
+    yii2:
+        config_path: %rootDir%/../../../tests/config/phpstan-params-config.php

--- a/tests/web/data/property/ApplicationParamsType.php
+++ b/tests/web/data/property/ApplicationParamsType.php
@@ -52,6 +52,11 @@ final class ApplicationParamsType
         assertType('null', Yii::$app->params['nullableParam']);
     }
 
+    public function testReturnStringFromDottedParamsKey(): void
+    {
+        assertType('string', Yii::$app->params['turnstile.siteKey']);
+    }
+
     public function testReturnStringFromParamsKey(): void
     {
         assertType('string', Yii::$app->params['adminEmail']);

--- a/tests/web/data/property/ApplicationParamsType.php
+++ b/tests/web/data/property/ApplicationParamsType.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\web\data\property;
+
+use Yii;
+
+use function PHPStan\Testing\assertType;
+
+/**
+ * Type assertion fixture for `Yii::$app->params` type inference in PHPStan analysis.
+ *
+ * Validates that PHPStan correctly infers array shape types for application params when configured via the extension
+ * configuration file.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.4.1
+ */
+final class ApplicationParamsType
+{
+    public function testReturnArrayShapeFromParams(): void
+    {
+        assertType(
+            "array{'turnstile.siteKey': string, adminEmail: string, maxItems: int, debugMode: bool, ratio: float, nullableParam: null, nested: array{key1: string, key2: int}, tags: array{string, string}}",
+            Yii::$app->params,
+        );
+    }
+
+    public function testReturnBoolFromParamsKey(): void
+    {
+        assertType('bool', Yii::$app->params['debugMode']);
+    }
+
+    public function testReturnFloatFromParamsKey(): void
+    {
+        assertType('float', Yii::$app->params['ratio']);
+    }
+
+    public function testReturnIntFromParamsKey(): void
+    {
+        assertType('int', Yii::$app->params['maxItems']);
+    }
+
+    public function testReturnNestedArrayShapeFromParamsKey(): void
+    {
+        assertType('array{key1: string, key2: int}', Yii::$app->params['nested']);
+    }
+
+    public function testReturnNullFromParamsKey(): void
+    {
+        assertType('null', Yii::$app->params['nullableParam']);
+    }
+
+    public function testReturnStringFromParamsKey(): void
+    {
+        assertType('string', Yii::$app->params['adminEmail']);
+    }
+}

--- a/tests/web/property/ApplicationParamsTypeTest.php
+++ b/tests/web/property/ApplicationParamsTypeTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace yii2\extensions\phpstan\tests\web\property;
+
+use PHPStan\Testing\TypeInferenceTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Unit tests for {@see ApplicationPropertiesClassReflectionExtension} params type inference.
+ *
+ * Validates that PHPStan correctly infers array shape types for `Yii::$app->params` when configured via the extension
+ * configuration file.
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 0.4.1
+ */
+final class ApplicationParamsTypeTest extends TypeInferenceTestCase
+{
+    /**
+     * @return iterable<mixed>
+     */
+    public static function dataFileAsserts(): iterable
+    {
+        $directory = dirname(__DIR__);
+
+        yield from self::gatherAssertTypes(
+            "{$directory}/data/property/ApplicationParamsType.php",
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [dirname(__DIR__, 2) . '/support/extension-params-test.neon'];
+    }
+
+    #[DataProvider('dataFileAsserts')]
+    public function testFileAsserts(string $assertType, string $file, mixed ...$args): void
+    {
+        $this->assertFileAsserts($assertType, $file, ...$args);
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ❌                                                              |
| New feature? | ✔️                                                              |
| Breaks BC?   | ❌                                                              |
