### PR TITLE
refactor: clean up `ServiceMap::class` by moving Yii environment constants to a shipped `bootstrap.php` (loaded before requiring the configuration file) and simplifying config-section processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: update badge links and remove quality code section from `README.md`.
 - docs: normalize PHPDoc headers across `src` and `tests`, and move authorship metadata to `composer.json`.
 - fix: harden `ServiceMap::class` config path validation (regular readable `.php` file, resolve symlinks before `require`) to prevent local file disclosure.
+- refactor: clean up `ServiceMap::class` by moving Yii environment constants to a shipped `bootstrap.php` (loaded via `extension.neon` `bootstrapFiles`) and simplifying config-section processing.
 
 ## 0.4.1 April 05, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: update badge links and remove quality code section from `README.md`.
 - docs: normalize PHPDoc headers across `src` and `tests`, and move authorship metadata to `composer.json`.
 - fix: harden `ServiceMap::class` config path validation (regular readable `.php` file, resolve symlinks before `require`) to prevent local file disclosure.
-- refactor: clean up `ServiceMap::class` by moving Yii environment constants to a shipped `bootstrap.php` (loaded via `extension.neon` `bootstrapFiles`) and simplifying config-section processing.
+- refactor: clean up `ServiceMap::class` by moving Yii environment constants to a shipped `bootstrap.php` (loaded before requiring the configuration file) and simplifying config-section processing.
 
 ## 0.4.1 April 05, 2026
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+defined('YII_DEBUG') || define('YII_DEBUG', true);
+defined('YII_ENV_DEV') || define('YII_ENV_DEV', false);
+defined('YII_ENV_PROD') || define('YII_ENV_PROD', false);
+defined('YII_ENV_TEST') || define('YII_ENV_TEST', true);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,10 +129,10 @@ parameters:
         - YII_ENV_TEST
 ```
 
-> `dynamicConstantNames` controls how PHPStan *treats* these constants during analysis (as non-constant values). It is
-> independent of *defining* them: the extension's shipped `bootstrap.php` defines `YII_DEBUG`, `YII_ENV_DEV`,
-> `YII_ENV_PROD`, and `YII_ENV_TEST` with safe defaults at startup, so configuration files that reference them load
-> without a manual bootstrap.
+> `dynamicConstantNames` controls how PHPStan _treats_ these constants during analysis (as non-constant values). It is
+> independent of _defining_ them: the extension's shipped `bootstrap.php` defines `YII_DEBUG`, `YII_ENV_DEV`,
+> `YII_ENV_PROD`, and `YII_ENV_TEST` with safe defaults before reading your configuration file, so configuration files
+> that reference them load without a manual bootstrap.
 
 ### Adding custom constants
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -129,6 +129,11 @@ parameters:
         - YII_ENV_TEST
 ```
 
+> `dynamicConstantNames` controls how PHPStan *treats* these constants during analysis (as non-constant values). It is
+> independent of *defining* them: the extension's shipped `bootstrap.php` defines `YII_DEBUG`, `YII_ENV_DEV`,
+> `YII_ENV_PROD`, and `YII_ENV_TEST` with safe defaults at startup, so configuration files that reference them load
+> without a manual bootstrap.
+
 ### Adding custom constants
 
 ⚠️ **Important**: When you define `dynamicConstantNames`, it **replaces** the defaults. Include Yii constants explicitly.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -215,7 +215,7 @@ vendor/bin/phpstan analyse test-phpstan.php --level=5
 
 ## Bootstrap configuration
 
-The extension ships a `bootstrap.php` (loaded automatically through `extension.neon`) that defines `YII_DEBUG`,
+The extension ships a `bootstrap.php` that it loads before reading your configuration file, defining `YII_DEBUG`,
 `YII_ENV_DEV`, `YII_ENV_PROD`, and `YII_ENV_TEST` with safe analysis defaults, so most projects don't need to define
 them manually. Existing definitions are preserved.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -215,7 +215,12 @@ vendor/bin/phpstan analyse test-phpstan.php --level=5
 
 ## Bootstrap configuration
 
-If your application requires custom bootstrap logic, create a bootstrap file (for example, `tests/bootstrap.php`).
+The extension ships a `bootstrap.php` (loaded automatically through `extension.neon`) that defines `YII_DEBUG`,
+`YII_ENV_DEV`, `YII_ENV_PROD`, and `YII_ENV_TEST` with safe analysis defaults, so most projects don't need to define
+them manually. Existing definitions are preserved.
+
+If your application requires additional bootstrap logic — autoloading Yii, defining `YII_ENV` (the environment string),
+or your own constants — create a bootstrap file (for example, `tests/bootstrap.php`).
 
 ```php
 <?php

--- a/extension.neon
+++ b/extension.neon
@@ -1,4 +1,7 @@
 parameters:
+    bootstrapFiles:
+        - bootstrap.php
+
     dynamicConstantNames:
         - YII_DEBUG
         - YII_ENV

--- a/extension.neon
+++ b/extension.neon
@@ -1,7 +1,4 @@
 parameters:
-    bootstrapFiles:
-        - bootstrap.php
-
     dynamicConstantNames:
         - YII_DEBUG
         - YII_ENV

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -13,8 +13,6 @@ use yii\base\{BaseObject, InvalidArgumentException};
 use yii\web\Application;
 
 use function array_key_exists;
-use function define;
-use function defined;
 use function gettype;
 use function is_array;
 use function is_file;
@@ -114,19 +112,14 @@ final class ServiceMap
             $configPath = $resolvedPath;
         }
 
-        defined('YII_DEBUG') || define('YII_DEBUG', true);
-        defined('YII_ENV_DEV') || define('YII_ENV_DEV', false);
-        defined('YII_ENV_PROD') || define('YII_ENV_PROD', false);
-        defined('YII_ENV_TEST') || define('YII_ENV_TEST', true);
-
         $config = $this->loadConfig($configPath);
 
         $this->processApplicationType($config);
         $this->processBehaviors($config);
         $this->processComponents($config);
-        $this->processDefinition($config);
         $this->processParams($config);
-        $this->processSingletons($config);
+        $this->processServices($config, 'definitions', 'Definition');
+        $this->processServices($config, 'singletons', 'Singleton');
     }
 
     /**
@@ -241,6 +234,31 @@ final class ServiceMap
     public function getServiceById(string $id): string|null
     {
         return $this->services[$id] ?? null;
+    }
+
+    /**
+     * Extracts a nested configuration section as an array.
+     *
+     * Traverses the provided keys in order, returning the value at that path when it is an array, or an empty array
+     * when any segment is missing or not an array.
+     *
+     * @param array $config Yii Application configuration array to traverse.
+     * @param string ...$keys Ordered keys identifying the nested section (for example, `'container'`, `'definitions'`).
+     *
+     * @return array Configuration section, or an empty array when the path is absent or not an array.
+     *
+     * @phpstan-param array<array-key, mixed> $config
+     * @phpstan-return array<array-key, mixed>
+     */
+    private function arraySection(array $config, string ...$keys): array
+    {
+        $value = $config;
+
+        foreach ($keys as $key) {
+            $value = is_array($value) ? ($value[$key] ?? null) : null;
+        }
+
+        return is_array($value) ? $value : [];
     }
 
     /**
@@ -402,23 +420,18 @@ final class ServiceMap
      */
     private function processBehaviors(array $config): void
     {
-        if ($config !== []) {
-            $behaviors = $config['behaviors'] ?? [];
-            $behaviors = is_array($behaviors) ? $behaviors : [];
-
-            foreach ($behaviors as $id => $definition) {
-                if (is_string($id) === false) {
-                    $this->throwErrorWhenIsNotString('Behavior class', 'ID', gettype($id));
-                }
-
-                if (is_array($definition) === false) {
-                    throw new RuntimeException(
-                        sprintf("Behavior definition for '%s' must be an array.", $id),
-                    );
-                }
-
-                $this->behaviors[$id] = array_values(array_filter($definition, is_string(...)));
+        foreach ($this->arraySection($config, 'behaviors') as $id => $definition) {
+            if (is_string($id) === false) {
+                $this->throwErrorWhenIsNotString('Behavior class', 'ID', gettype($id));
             }
+
+            if (is_array($definition) === false) {
+                throw new RuntimeException(
+                    sprintf("Behavior definition for '%s' must be an array.", $id),
+                );
+            }
+
+            $this->behaviors[$id] = array_values(array_filter($definition, is_string(...)));
         }
     }
 
@@ -436,70 +449,34 @@ final class ServiceMap
      */
     private function processComponents(array $config): void
     {
-        if ($config !== []) {
-            $components = $config['components'] ?? [];
-            $components = is_array($components) ? $components : [];
-
-            foreach ($components as $id => $definition) {
-                if (is_string($id) === false) {
-                    $this->throwErrorWhenIsNotString('Component', 'ID', gettype($id));
-                }
-
-                if (is_object($definition)) {
-                    $className = $definition::class;
-
-                    $this->components[$id] = $className;
-                    $this->componentClassToIdMap[$className] = $id;
-
-                    continue;
-                }
-
-                if (
-                    is_array($definition)
-                    && isset($definition['class'])
-                    && is_string($definition['class'])
-                    && $definition['class'] !== ''
-                ) {
-                    $className = $definition['class'];
-
-                    $this->components[$id] = $className;
-                    $this->componentClassToIdMap[$className] = $id;
-
-                    unset($definition['class']);
-
-                    $this->componentsDefinitions[$id] = $definition;
-                }
+        foreach ($this->arraySection($config, 'components') as $id => $definition) {
+            if (is_string($id) === false) {
+                $this->throwErrorWhenIsNotString('Component', 'ID', gettype($id));
             }
-        }
-    }
 
-    /**
-     * Processes service definitions from the Yii Application configuration array.
-     *
-     * Iterates over the container.definitions section of the provided configuration array, normalizing and registering
-     * each service definition by its identifier.
-     *
-     * @param array $config Yii Application configuration array containing service definitions.
-     *
-     * @throws ReflectionException if the service definition is invalid or can't be resolved.
-     * @throws RuntimeException if a runtime error prevents the operation from completing successfully.
-     *
-     * @phpstan-param array<array-key, mixed> $config
-     */
-    private function processDefinition(array $config): void
-    {
-        if ($config !== []) {
-            $container = $config['container'] ?? null;
-            $container = is_array($container) ? $container : [];
-            $definitions = $container['definitions'] ?? [];
-            $definitions = is_array($definitions) ? $definitions : [];
+            if (is_object($definition)) {
+                $className = $definition::class;
 
-            foreach ($definitions as $id => $service) {
-                if (is_string($id) === false) {
-                    $this->throwErrorWhenIsNotString('Definition', 'ID', gettype($id));
-                }
+                $this->components[$id] = $className;
+                $this->componentClassToIdMap[$className] = $id;
 
-                $this->services[$id] = $this->normalizeDefinition($id, $service);
+                continue;
+            }
+
+            if (
+                is_array($definition)
+                && isset($definition['class'])
+                && is_string($definition['class'])
+                && $definition['class'] !== ''
+            ) {
+                $className = $definition['class'];
+
+                $this->components[$id] = $className;
+                $this->componentClassToIdMap[$className] = $id;
+
+                unset($definition['class']);
+
+                $this->componentsDefinitions[$id] = $definition;
             }
         }
     }
@@ -515,40 +492,32 @@ final class ServiceMap
      */
     private function processParams(array $config): void
     {
-        if ($config !== []) {
-            $params = $config['params'] ?? [];
-            $this->params = is_array($params) ? $params : [];
-        }
+        $this->params = $this->arraySection($config, 'params');
     }
 
     /**
-     * Processes singleton service definitions from the Yii Application configuration array.
+     * Processes container service definitions from the Yii Application configuration array.
      *
-     * Iterates over the container.singletons section of the provided configuration array, normalizing and registering
-     * each singleton service definition by its identifier.
+     * Iterates over the specified `container` subsection, normalizing and registering each service definition by its
+     * identifier.
      *
-     * @param array $config Yii Application configuration array containing singleton definitions.
+     * @param array $config Yii Application configuration array containing container definitions.
+     * @param string $section Container subsection to process (`'definitions'` or `'singletons'`).
+     * @param string $label Label used in error messages to identify the subsection (`'Definition'` or `'Singleton'`).
      *
      * @throws ReflectionException if the service definition is invalid or can't be resolved.
      * @throws RuntimeException if a runtime error prevents the operation from completing successfully.
      *
      * @phpstan-param array<array-key, mixed> $config
      */
-    private function processSingletons(array $config): void
+    private function processServices(array $config, string $section, string $label): void
     {
-        if ($config !== []) {
-            $container = $config['container'] ?? null;
-            $container = is_array($container) ? $container : [];
-            $singletons = $container['singletons'] ?? [];
-            $singletons = is_array($singletons) ? $singletons : [];
-
-            foreach ($singletons as $id => $service) {
-                if (is_string($id) === false) {
-                    $this->throwErrorWhenIsNotString('Singleton', 'ID', gettype($id));
-                }
-
-                $this->services[$id] = $this->normalizeDefinition($id, $service);
+        foreach ($this->arraySection($config, 'container', $section) as $id => $service) {
+            if (is_string($id) === false) {
+                $this->throwErrorWhenIsNotString($label, 'ID', gettype($id));
             }
+
+            $this->services[$id] = $this->normalizeDefinition($id, $service);
         }
     }
 

--- a/src/ServiceMap.php
+++ b/src/ServiceMap.php
@@ -13,6 +13,7 @@ use yii\base\{BaseObject, InvalidArgumentException};
 use yii\web\Application;
 
 use function array_key_exists;
+use function dirname;
 use function gettype;
 use function is_array;
 use function is_file;
@@ -111,6 +112,8 @@ final class ServiceMap
 
             $configPath = $resolvedPath;
         }
+
+        require_once dirname(__DIR__) . '/bootstrap.php';
 
         $config = $this->loadConfig($configPath);
 

--- a/tests/support/bootstrap.php
+++ b/tests/support/bootstrap.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 error_reporting(-1);
 
-defined('YII_DEBUG') || define('YII_DEBUG', true);
-define('YII_ENABLE_ERROR_HANDLER', false);
-define('YII_ENV', 'test');
-
 // root directory of the project
 $rootDir = dirname(__DIR__, 2);
+
+// shared Yii environment constants (same definitions shipped to consumers via 'extension.neon')
+require_once "{$rootDir}/bootstrap.php";
+
+define('YII_ENABLE_ERROR_HANDLER', false);
+define('YII_ENV', 'test');
 
 // require composer autoloader if available
 require "{$rootDir}/vendor/autoload.php";


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [ ] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)